### PR TITLE
fix(cmake): update FetchContent URLs from AethOS-EoS to embeddedos-org

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -25,9 +25,9 @@ option(EOS_FETCH_DEPS   "Auto-fetch deps via git if not found"    ON)
 set(EBOOT_SOURCE_DIR  "" CACHE PATH "Explicit path to eBoot source tree")
 set(EBUILD_SOURCE_DIR "" CACHE PATH "Explicit path to ebuild source tree")
 
-set(EOS_EBOOT_GIT_REPO  "https://github.com/AethOS-EoS/eBoot.git" CACHE STRING "eBoot git URL")
+set(EOS_EBOOT_GIT_REPO  "https://github.com/embeddedos-org/eBoot.git" CACHE STRING "eBoot git URL")
 set(EOS_EBOOT_GIT_TAG   "main" CACHE STRING "eBoot git tag/branch to fetch")
-set(EOS_EBUILD_GIT_REPO "https://github.com/AethOS-EoS/ebuild.git" CACHE STRING "ebuild git URL")
+set(EOS_EBUILD_GIT_REPO "https://github.com/embeddedos-org/ebuild.git" CACHE STRING "ebuild git URL")
 set(EOS_EBUILD_GIT_TAG  "main" CACHE STRING "ebuild git tag/branch to fetch")
 
 # ====================================================================


### PR DESCRIPTION
## Summary
Fixes CI build failures caused by stale git clone URLs.

## Changes
- Updated eBoot URL: `AethOS-EoS/eBoot` -> `embeddedos-org/eBoot`
- Updated ebuild URL: `AethOS-EoS/ebuild` -> `embeddedos-org/ebuild`

## Testing
- CI should now pass on all 3 platforms (Linux, macOS, Windows)
- CMake FetchContent will clone from the correct repos