### PR TITLE
ci: add CODEOWNERS requiring admin approval on all PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,23 @@
+name: Auto Assign PR
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR to author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login]
+            });

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — at least one admin must approve every PR
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: require admin review on all files
+*   @srpatcha @hshanmug12 @maheshmunnangi @rashmiadvani


### PR DESCRIPTION
Adds CODEOWNERS file: every PR requires approval from at least one org admin (@srpatcha, @hshanmug12, @maheshmunnangi, @rashmiadvani).