### PR TITLE
fix: update PGP key URLs in SECURITY.md and artifact-verification docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ Fingerprint: XXXX XXXX XXXX XXXX XXXX  XXXX XXXX XXXX XXXX XXXX
 Key ID: 0xXXXXXXXX
 ```
 
-The public key is available at `https://embeddedos.org/.well-known/pgp-key.asc` and on major keyservers.
+The public key is available at `https://embeddedos-org.github.io/.well-known/pgp-key.asc` and on major keyservers.
 
 ### What to Include
 

--- a/docs/release/artifact-verification.md
+++ b/docs/release/artifact-verification.md
@@ -70,7 +70,7 @@ If verification fails, **do not use the artifact**. Report the issue to security
 
 ```bash
 # Download the public key
-curl -LO https://embeddedos.org/.well-known/pgp-key.asc
+curl -LO https://embeddedos-org.github.io/.well-known/pgp-key.asc
 
 # Import into your GPG keyring
 gpg --import pgp-key.asc


### PR DESCRIPTION
Changes:
- Updated PGP key URL in SECURITY.md from embeddedos.org to embeddedos-org.github.io
- Updated PGP key download URL in docs/release/artifact-verification.md