### PR TITLE
fix: prevent integer overflow in kernel heap allocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(eos_kernel STATIC
     kernel/src/sync.c
     kernel/src/ipc.c
     kernel/src/multicore.c
+    kernel/src/mem/heap.c
 )
 
 target_include_directories(eos_kernel PUBLIC

--- a/kernel/src/mem/heap.c
+++ b/kernel/src/mem/heap.c
@@ -63,8 +63,14 @@ void *eos_malloc(size_t size)
 {
     if (size == 0 || !free_list) return NULL;
 
+    /* Both alignment and header addition must be representable.  Without
+     * these guards, a request close to SIZE_MAX wraps to a small value and
+     * can return an undersized allocation to the caller. */
+    if (size > SIZE_MAX - 7) return NULL;
+
     /* Align allocation size to 8 bytes */
     size = ALIGN_UP(size, 8);
+    if (size > SIZE_MAX - HEADER_SIZE) return NULL;
     size_t total_needed = size + HEADER_SIZE;
 
     /* Best-fit search */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,11 @@ add_executable(test_kernel test_kernel.c)
 target_link_libraries(test_kernel PRIVATE eos_kernel)
 add_test(NAME test_kernel COMMAND test_kernel)
 
+# --- test_heap: Kernel allocator and overflow handling ---
+add_executable(test_heap test_heap.c)
+target_link_libraries(test_heap PRIVATE eos_kernel)
+add_test(NAME test_heap COMMAND test_heap)
+
 # --- test_multicore: Multicore framework ---
 add_executable(test_multicore test_multicore.c)
 target_link_libraries(test_multicore PRIVATE eos_kernel)

--- a/tests/test_heap.c
+++ b/tests/test_heap.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EoS Project
+
+#include "eos/mem.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+static uint8_t heap_area[512];
+
+int main(void)
+{
+    if (eos_heap_init(heap_area, sizeof(heap_area)) != 0) {
+        fprintf(stderr, "heap initialization failed\n");
+        return 1;
+    }
+
+    if (eos_malloc(SIZE_MAX) != NULL) {
+        fprintf(stderr, "SIZE_MAX allocation must be rejected\n");
+        return 1;
+    }
+
+    if (eos_malloc(SIZE_MAX - 3) != NULL) {
+        fprintf(stderr, "alignment-overflow allocation must be rejected\n");
+        return 1;
+    }
+
+    void *allocation = eos_malloc(32);
+    if (allocation == NULL) {
+        fprintf(stderr, "valid allocation failed after rejected requests\n");
+        return 1;
+    }
+
+    eos_free(allocation);
+    return 0;
+}


### PR DESCRIPTION
## Problem

`eos_malloc()` aligns the requested size and then adds the internal block-header size without first checking whether either calculation can overflow `size_t`.

For requests close to `SIZE_MAX`, the arithmetic can wrap to a small value. The allocator may then return a valid-looking pointer to a block that is much smaller than requested, potentially leading to out-of-bounds writes.

The heap implementation was also not included in the `eos_kernel` CMake target, despite the allocator API being publicly exposed.

## Solution

- Reject allocation sizes that would overflow during 8-byte alignment.
- Reject sizes that would overflow when adding `HEADER_SIZE`.
- Add `kernel/src/mem/heap.c` to the `eos_kernel` target.
- Add a dedicated CTest target for the heap allocator.
- Add regression coverage for `SIZE_MAX`, alignment overflow, and a valid allocation after rejected requests.

## Testing

Built and executed the dedicated test on a Windows host using CMake, Ninja, and Zig/Clang 21:

`cmake --build build/codex --target test_heap`

`ctest --test-dir build/codex -R "^test_heap$" --output-on-failure`

Result:

`100% tests passed, 1/1`

The regression test was run against the previous implementation and failed with:

`SIZE_MAX allocation must be rejected`

## Additional considerations

This change only rejects unrepresentable allocation sizes. It does not change the allocator's best-fit, splitting, coalescing, or statistics behavior.