### PR TITLE
fix: reject invalid dependency graph inputs

### DIFF
--- a/core/src/graph.c
+++ b/core/src/graph.c
@@ -8,11 +8,15 @@
 #include <stdio.h>
 
 void eos_graph_init(EosGraph *g) {
+    if (!g) return;
     memset(g, 0, sizeof(*g));
 }
 
 EosResult eos_graph_add_node(EosGraph *g, const char *name, EosNodeType type,
                                  EosBuildType build_type, int *out_id) {
+    if (!g || !name || name[0] == '\0' || strlen(name) >= EOS_MAX_NAME) {
+        return EOS_ERR_INVALID;
+    }
     if (g->node_count >= EOS_MAX_NODES) {
         EOS_ERROR("Graph node overflow (max %d)", EOS_MAX_NODES);
         return EOS_ERR_OVERFLOW;
@@ -34,6 +38,7 @@ EosResult eos_graph_add_node(EosGraph *g, const char *name, EosNodeType type,
 }
 
 EosResult eos_graph_add_edge(EosGraph *g, int from, int to) {
+    if (!g) return EOS_ERR_INVALID;
     if (from < 0 || from >= g->node_count || to < 0 || to >= g->node_count) {
         return EOS_ERR_INVALID;
     }
@@ -51,6 +56,7 @@ EosResult eos_graph_add_edge(EosGraph *g, int from, int to) {
 }
 
 int eos_graph_find_node(const EosGraph *g, const char *name) {
+    if (!g || !name) return -1;
     for (int i = 0; i < g->node_count; i++) {
         if (strcmp(g->nodes[i].name, name) == 0) return i;
     }
@@ -59,6 +65,7 @@ int eos_graph_find_node(const EosGraph *g, const char *name) {
 
 /* Kahn's algorithm for topological sort with cycle detection */
 EosResult eos_graph_topological_sort(EosGraph *g) {
+    if (!g) return EOS_ERR_INVALID;
     int in_degree[EOS_MAX_NODES] = {0};
 
     for (int i = 0; i < g->edge_count; i++) {
@@ -101,6 +108,7 @@ EosResult eos_graph_topological_sort(EosGraph *g) {
 }
 
 void eos_graph_dump(const EosGraph *g) {
+    if (!g) return;
     printf("Build Graph: %d nodes, %d edges\n", g->node_count, g->edge_count);
     for (int i = 0; i < g->node_count; i++) {
         printf("  [%d] %s (%s)\n", i, g->nodes[i].name,

--- a/tests/test_graph.c
+++ b/tests/test_graph.c
@@ -160,6 +160,42 @@ static void test_independent_nodes(void) {
     ASSERT(g.sorted_count == 3, "all 3 independent nodes sorted");
 }
 
+static void test_invalid_inputs(void) {
+    printf("test_invalid_inputs:\n");
+    EosGraph g;
+    eos_graph_init(&g);
+
+    ASSERT(eos_graph_add_node(NULL, "node", EOS_NODE_PACKAGE,
+                              EOS_BUILD_CMAKE, NULL) == EOS_ERR_INVALID,
+           "NULL graph is rejected");
+    ASSERT(eos_graph_add_node(&g, NULL, EOS_NODE_PACKAGE,
+                              EOS_BUILD_CMAKE, NULL) == EOS_ERR_INVALID,
+           "NULL node name is rejected");
+    ASSERT(eos_graph_add_node(&g, "", EOS_NODE_PACKAGE,
+                              EOS_BUILD_CMAKE, NULL) == EOS_ERR_INVALID,
+           "empty node name is rejected");
+
+    char long_name[EOS_MAX_NAME + 1];
+    memset(long_name, 'x', sizeof(long_name));
+    long_name[sizeof(long_name) - 1] = '\0';
+    ASSERT(eos_graph_add_node(&g, long_name, EOS_NODE_PACKAGE,
+                              EOS_BUILD_CMAKE, NULL) == EOS_ERR_INVALID,
+           "overlong node name is rejected instead of truncated");
+    ASSERT(g.node_count == 0, "invalid nodes do not mutate the graph");
+
+    ASSERT(eos_graph_add_edge(NULL, 0, 0) == EOS_ERR_INVALID,
+           "NULL graph edge is rejected");
+    ASSERT(eos_graph_find_node(NULL, "node") == -1,
+           "find handles NULL graph");
+    ASSERT(eos_graph_find_node(&g, NULL) == -1,
+           "find handles NULL name");
+    ASSERT(eos_graph_topological_sort(NULL) == EOS_ERR_INVALID,
+           "sort handles NULL graph");
+
+    eos_graph_init(NULL);
+    eos_graph_dump(NULL);
+}
+
 int main(void) {
     eos_log_set_level(EOS_LOG_ERROR);
 
@@ -172,6 +208,7 @@ int main(void) {
     test_topological_sort_diamond();
     test_cycle_detection();
     test_independent_nodes();
+    test_invalid_inputs();
 
     printf("\n=== Results: %d/%d passed ===\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;


### PR DESCRIPTION
## Problem

The public dependency-graph API dereferences graph and name pointers without validation. Invalid inputs can therefore crash the process instead of returning `EOS_ERR_INVALID`.

Node names that exceed `EOS_MAX_NAME - 1` are also silently truncated by `strncpy`. A caller can add such a node successfully but fail to find it later using the original name, leaving inconsistent graph state.

## Solution

- Make graph initialization and dump operations safe for null graph pointers.
- Reject null graph pointers in mutating and sorting operations.
- Reject null, empty, and overlong node names.
- Make node lookup safely return `-1` for invalid inputs.
- Add regression tests confirming rejected inputs do not mutate graph state.

## Testing

Built and executed the graph test on a Windows host using CMake, Ninja, and Zig/Clang 21:

`cmake --build build/codex --target test_graph`

`ctest --test-dir build/codex -R "^test_graph$" --output-on-failure`

Result:

`100% tests passed, 1/1`

Without the new validation, the regression test reproduced a null-pointer panic in `eos_graph_add_node()`.

## Additional considerations

Behavior for valid graph inputs is unchanged. Overlong names are rejected rather than silently truncated so that successful insertion and lookup remain consistent.