### PR TITLE
fix(kernel): reject overflowing queue, sem, and mutex nest counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **`eos_queue_create`:** Size check now uses division so `item_size * capacity` cannot wrap `size_t` on 32-bit targets and overflow the 1024-byte queue store.
+- **`eos_sem_create`:** Reject `initial > max` and `max` values that do not fit in `int32_t`, so the counting-semaphore invariant cannot be created already broken.
+- **`eos_mutex_lock`:** Recursive lock returns `EOS_KERN_FULL` at `uint8_t` saturation instead of wrapping `rec_count` to 0 and leaving the mutex stuck.
+
 ## [3.0.1] - 2026-05-16
 
 ### Production Release — Unified EmbeddedOS-org v3.0.1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -111,14 +111,14 @@ All extended peripherals are conditionally compiled behind `EOS_ENABLE_*` flags.
 | Function | Description |
 |----------|-------------|
 | `eos_mutex_create(eos_mutex_handle_t *out)` | Create a mutex. |
-| `eos_mutex_lock(handle, timeout_ms)` | Lock with timeout. Use `EOS_WAIT_FOREVER`. |
+| `eos_mutex_lock(handle, timeout_ms)` | Lock with timeout. Use `EOS_WAIT_FOREVER`. Recursive; returns `EOS_KERN_FULL` if the nest count would wrap (`uint8_t` max). |
 | `eos_mutex_unlock(handle)` | Unlock. |
 
 ### Semaphore
 
 | Function | Description |
 |----------|-------------|
-| `eos_sem_create(out, initial, max)` | Create counting semaphore. |
+| `eos_sem_create(out, initial, max)` | Create counting semaphore. Returns `EOS_KERN_INVALID` if `max == 0`, `initial > max`, or `max` does not fit in `int32_t`. |
 | `eos_sem_wait(handle, timeout_ms)` | Wait (decrement). |
 | `eos_sem_post(handle)` | Signal (increment). |
 
@@ -126,7 +126,7 @@ All extended peripherals are conditionally compiled behind `EOS_ENABLE_*` flags.
 
 | Function | Description |
 |----------|-------------|
-| `eos_queue_create(out, item_size, capacity)` | Create queue. |
+| `eos_queue_create(out, item_size, capacity)` | Create queue. Returns `EOS_KERN_NO_MEMORY` if `item_size * capacity` exceeds the 1024-byte backing store (checked without overflowing `size_t`). |
 | `eos_queue_send(handle, item, timeout_ms)` | Send item to queue. |
 | `eos_queue_receive(handle, item, timeout_ms)` | Receive item from queue. |
 | `eos_queue_count(handle)` | Get current queue depth. |

--- a/kernel/src/ipc.c
+++ b/kernel/src/ipc.c
@@ -33,7 +33,9 @@ static queue_t g_q[EOS_MAX_QUEUES];
 int eos_queue_create(eos_queue_handle_t *out, size_t item_size, uint32_t capacity)
 {
     if (!out || item_size == 0 || capacity == 0) return EOS_KERN_INVALID;
-    if (item_size * capacity > sizeof(g_q[0]._storage)) return EOS_KERN_NO_MEMORY;
+    /* Compare via division so item_size * capacity cannot wrap size_t
+     * (e.g. item_size=0x10000000, capacity=16 on 32-bit targets). */
+    if (capacity > sizeof(g_q[0]._storage) / item_size) return EOS_KERN_NO_MEMORY;
 
     uint32_t crit = eos_port_enter_critical();
     for (int i = 0; i < EOS_MAX_QUEUES; i++) {

--- a/kernel/src/sync.c
+++ b/kernel/src/sync.c
@@ -11,6 +11,7 @@
 #include "eos/kernel_internal.h"
 #include "eos/arch.h"
 #include <string.h>
+#include <stdint.h>
 
 /* ============================================================
  * Mutex — with priority inheritance and timeout blocking
@@ -76,6 +77,10 @@ int eos_mutex_lock(eos_mutex_handle_t h, uint32_t timeout_ms)
 
     /* Recursive lock by owner */
     if (g_mtx[h].owner == caller) {
+        if (g_mtx[h].rec_count == UINT8_MAX) {
+            eos_port_exit_critical(crit);
+            return EOS_KERN_FULL;
+        }
         g_mtx[h].rec_count++;
         eos_port_exit_critical(crit);
         return EOS_KERN_OK;
@@ -185,7 +190,8 @@ int eos_mutex_delete(eos_mutex_handle_t h)
 
 int eos_sem_create(eos_sem_handle_t *out, uint32_t initial, uint32_t max)
 {
-    if (!out || max == 0) return EOS_KERN_INVALID;
+    if (!out || max == 0 || initial > max) return EOS_KERN_INVALID;
+    if (max > (uint32_t)INT32_MAX) return EOS_KERN_INVALID;
     uint32_t crit = eos_port_enter_critical();
     for (int i = 0; i < EOS_MAX_SEMAPHORES; i++) {
         if (!g_sem[i].in_use) {

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -60,6 +60,15 @@ static void test_mutex(void) {
     assert(eos_mutex_unlock(m) == EOS_KERN_OK);
     assert(eos_mutex_delete(m) == EOS_KERN_OK);
     assert(eos_mutex_create(NULL) == EOS_KERN_INVALID);
+
+    assert(eos_mutex_create(&m) == EOS_KERN_OK);
+    for (int i = 0; i < 255; i++)
+        assert(eos_mutex_lock(m, 0) == EOS_KERN_OK);
+    assert(eos_mutex_lock(m, 0) == EOS_KERN_FULL);
+    for (int i = 0; i < 255; i++)
+        assert(eos_mutex_unlock(m) == EOS_KERN_OK);
+    assert(eos_mutex_unlock(m) == EOS_KERN_INVALID);
+    assert(eos_mutex_delete(m) == EOS_KERN_OK);
     printf("[PASS] mutex\n");
 }
 
@@ -79,6 +88,8 @@ static void test_semaphore(void) {
     assert(eos_sem_delete(s) == EOS_KERN_OK);
     assert(eos_sem_create(NULL, 1, 5) == EOS_KERN_INVALID);
     assert(eos_sem_create(&s, 0, 0) == EOS_KERN_INVALID);
+    assert(eos_sem_create(&s, 10, 5) == EOS_KERN_INVALID);
+    assert(eos_sem_create(&s, 1, 0x80000000u) == EOS_KERN_INVALID);
     printf("[PASS] semaphore\n");
 }
 
@@ -100,6 +111,10 @@ static void test_queue(void) {
     assert(eos_queue_delete(q) == EOS_KERN_OK);
     assert(eos_queue_create(NULL, 4, 4) == EOS_KERN_INVALID);
     assert(eos_queue_create(&q, 0, 4) == EOS_KERN_INVALID);
+    assert(eos_queue_create(&q, 64, 16) == EOS_KERN_OK);
+    assert(eos_queue_delete(q) == EOS_KERN_OK);
+    assert(eos_queue_create(&q, 64, 17) == EOS_KERN_NO_MEMORY);
+    assert(eos_queue_create(&q, (size_t)0x10000000u, 16u) == EOS_KERN_NO_MEMORY);
     printf("[PASS] queue\n");
 }
 


### PR DESCRIPTION
## Summary

Three kernel create/lock paths accepted values that break their own invariants.

`eos_queue_create` multiplied `item_size * capacity` before comparing it to the 1024-byte store. On 32-bit `size_t` that product can wrap to a small number, the check passes, and later `memcpy` writes past `_storage`.

`eos_sem_create` allowed `initial > max`, so a counting semaphore could start already above its ceiling. `eos_sem_post` then refuses further posts and the count never returns to a legal range.

`eos_mutex_lock` stores the recursive nest count in a `uint8_t`. The 256th nested lock wraps `rec_count` to 0; the next unlock underflows and the mutex stays held.

## Type of Change

- [x] fix — Bug fix

## Changes

- Compare queue capacity with division so the size check cannot wrap `size_t`.
- Reject `initial > max` and `max` values that do not fit in `int32_t` at semaphore create.
- Return `EOS_KERN_FULL` when a recursive lock would overflow `uint8_t`.
- Extend `tests/test_kernel.c` for all three cases. Document the contracts in `docs/api-reference.md`.

## Testing

- [x] Unit tests pass (`test_kernel.exe` — 9/9)
- [x] New tests added for new functionality

Related host tests also passed: config, graph, crypto, HAL, drivers. Full-tree `ctest` on this Windows/zig host still hits pre-existing sensor/net/multicore/OTA failures unrelated to this change.