### PR TITLE
fix(sensor): honor configurable filter windows

### DIFF
--- a/services/sensor/CMakeLists.txt
+++ b/services/sensor/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(eos_sensor STATIC
     src/sensor.c
 )
 
+target_compile_definitions(eos_sensor PUBLIC EOS_ENABLE_SENSOR=1)
+
 target_include_directories(eos_sensor PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/include

--- a/services/sensor/include/eos/sensor.h
+++ b/services/sensor/include/eos/sensor.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #define EOS_SENSOR_MAX 16
+#define EOS_SENSOR_FILTER_MAX_WINDOW 32
 
 typedef enum {
     EOS_SENSOR_TEMPERATURE  = 0,

--- a/services/sensor/src/sensor.c
+++ b/services/sensor/src/sensor.c
@@ -7,13 +7,11 @@
 
 #if EOS_ENABLE_SENSOR
 
-#define FILTER_WIN 8
-
 typedef struct {
     eos_sensor_config_t cfg;
     eos_sensor_calib_t  calib;
     uint8_t  in_use;
-    float    filter_buf[FILTER_WIN];
+    float    filter_buf[EOS_SENSOR_FILTER_MAX_WINDOW];
     int      filter_idx;
     int      filter_count;
     float    last_filtered;
@@ -24,13 +22,37 @@ static sensor_ctx_t g_s[EOS_SENSOR_MAX];
 static int g_count = 0;
 static int g_init = 0;
 
+static int filter_requires_window(eos_filter_type_t filter) {
+    return filter == EOS_FILTER_AVERAGE || filter == EOS_FILTER_MEDIAN;
+}
+
+static int is_valid_filter(eos_filter_type_t filter) {
+    return filter >= EOS_FILTER_NONE && filter <= EOS_FILTER_KALMAN;
+}
+
+static int is_valid_filter_window(eos_filter_type_t filter, uint8_t window_size) {
+    if (!filter_requires_window(filter)) return 1;
+    return window_size <= EOS_SENSOR_FILTER_MAX_WINDOW;
+}
+
+static uint8_t normalize_filter_window(eos_filter_type_t filter, uint8_t window_size) {
+    if (!filter_requires_window(filter)) return 0;
+    return window_size == 0 ? EOS_SENSOR_FILTER_MAX_WINDOW : window_size;
+}
+
+static uint8_t active_filter_window(const sensor_ctx_t *s) {
+    return s->cfg.filter_window == 0 ? EOS_SENSOR_FILTER_MAX_WINDOW : s->cfg.filter_window;
+}
+
 int eos_sensor_init(void) { memset(g_s, 0, sizeof(g_s)); g_count = 0; g_init = 1; return 0; }
 void eos_sensor_deinit(void) { g_init = 0; g_count = 0; }
 
 int eos_sensor_register(const eos_sensor_config_t *cfg) {
     if (!g_init || !cfg || cfg->id >= EOS_SENSOR_MAX || g_s[cfg->id].in_use) return -1;
+    if (!is_valid_filter(cfg->filter) || !is_valid_filter_window(cfg->filter, cfg->filter_window)) return -1;
     memset(&g_s[cfg->id], 0, sizeof(sensor_ctx_t));
     g_s[cfg->id].cfg = *cfg;
+    g_s[cfg->id].cfg.filter_window = normalize_filter_window(cfg->filter, cfg->filter_window);
     g_s[cfg->id].calib.scale = 1.0f;
     g_s[cfg->id].in_use = 1;
     g_count++;
@@ -55,18 +77,21 @@ int eos_sensor_read(uint8_t id, eos_sensor_reading_t *r) {
 }
 
 static float do_avg(sensor_ctx_t *s, float v) {
+    const int window = active_filter_window(s);
     s->filter_buf[s->filter_idx] = v;
-    s->filter_idx = (s->filter_idx + 1) % FILTER_WIN;
-    if (s->filter_count < FILTER_WIN) s->filter_count++;
+    s->filter_idx = (s->filter_idx + 1) % window;
+    if (s->filter_count < window) s->filter_count++;
     float sum = 0; for (int i = 0; i < s->filter_count; i++) sum += s->filter_buf[i];
     return sum / (float)s->filter_count;
 }
 
 static float do_median(sensor_ctx_t *s, float v) {
+    const int window = active_filter_window(s);
     s->filter_buf[s->filter_idx] = v;
-    s->filter_idx = (s->filter_idx + 1) % FILTER_WIN;
-    if (s->filter_count < FILTER_WIN) s->filter_count++;
-    float sorted[FILTER_WIN]; memcpy(sorted, s->filter_buf, sizeof(float) * (size_t)s->filter_count);
+    s->filter_idx = (s->filter_idx + 1) % window;
+    if (s->filter_count < window) s->filter_count++;
+    float sorted[EOS_SENSOR_FILTER_MAX_WINDOW];
+    memcpy(sorted, s->filter_buf, sizeof(float) * (size_t)s->filter_count);
     for (int i = 0; i < s->filter_count - 1; i++)
         for (int j = i + 1; j < s->filter_count; j++)
             if (sorted[j] < sorted[i]) { float t = sorted[i]; sorted[i] = sorted[j]; sorted[j] = t; }
@@ -114,10 +139,12 @@ int eos_sensor_auto_calibrate(uint8_t id) {
 
 int eos_sensor_set_filter(uint8_t id, eos_filter_type_t f, uint8_t window_size) {
     if (!g_init || id >= EOS_SENSOR_MAX || !g_s[id].in_use) return -1;
+    if (!is_valid_filter(f) || !is_valid_filter_window(f, window_size)) return -1;
     g_s[id].cfg.filter = f;
-    g_s[id].cfg.filter_window = window_size;
-    g_s[id].filter_idx = 0; g_s[id].filter_count = 0;
-    (void)window_size;
+    g_s[id].cfg.filter_window = normalize_filter_window(f, window_size);
+    g_s[id].filter_idx = 0;
+    g_s[id].filter_count = 0;
+    g_s[id].last_filtered = 0.0f;
     return 0;
 }
 

--- a/tests/test_sensor.c
+++ b/tests/test_sensor.c
@@ -27,6 +27,27 @@ static void test_sensor_register(void) {
     printf("[PASS] sensor register\n");
 }
 
+static void test_sensor_register_invalid_filter_config(void) {
+    eos_sensor_init();
+
+    eos_sensor_config_t bad_window_cfg; memset(&bad_window_cfg, 0, sizeof(bad_window_cfg));
+    bad_window_cfg.id = 0;
+    bad_window_cfg.filter = EOS_FILTER_AVERAGE;
+    bad_window_cfg.filter_window = EOS_SENSOR_FILTER_MAX_WINDOW + 1;
+    assert(eos_sensor_register(&bad_window_cfg) == -1);
+    assert(eos_sensor_get_count() == 0);
+
+    eos_sensor_config_t bad_filter_cfg; memset(&bad_filter_cfg, 0, sizeof(bad_filter_cfg));
+    bad_filter_cfg.id = 1;
+    bad_filter_cfg.filter = (eos_filter_type_t)99;
+    bad_filter_cfg.filter_window = 3;
+    assert(eos_sensor_register(&bad_filter_cfg) == -1);
+    assert(eos_sensor_get_count() == 0);
+
+    eos_sensor_deinit();
+    printf("[PASS] sensor register invalid filter config\n");
+}
+
 static void test_sensor_read(void) {
     eos_sensor_init();
     eos_sensor_config_t cfg; memset(&cfg, 0, sizeof(cfg));
@@ -64,8 +85,123 @@ static void test_sensor_filter(void) {
     eos_sensor_reading_t r;
     for (int i = 0; i < 10; i++)
         eos_sensor_read_filtered(0, &r);
+    assert(r.value > 5.4f && r.value < 5.6f);
     eos_sensor_deinit();
     printf("[PASS] sensor filter\n");
+}
+
+static void test_sensor_filter_window(void) {
+    eos_sensor_init();
+    eos_sensor_config_t cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.id = 0;
+    eos_sensor_register(&cfg);
+    assert(eos_sensor_set_filter(0, EOS_FILTER_AVERAGE, 3) == 0);
+
+    eos_sensor_reading_t r;
+    for (int i = 0; i < 5; i++)
+        eos_sensor_read_filtered(0, &r);
+
+    assert(r.value > 2.9f && r.value < 3.1f);
+
+    eos_sensor_config_t info;
+    assert(eos_sensor_get_info(0, &info) == 0);
+    assert(info.filter_window == 3);
+
+    eos_sensor_deinit();
+    printf("[PASS] sensor filter window\n");
+}
+
+static void test_sensor_filter_window_one(void) {
+    eos_sensor_init();
+    eos_sensor_config_t cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.id = 0;
+    eos_sensor_register(&cfg);
+    assert(eos_sensor_set_filter(0, EOS_FILTER_AVERAGE, 1) == 0);
+
+    eos_sensor_reading_t r;
+    for (int i = 0; i < 5; i++)
+        eos_sensor_read_filtered(0, &r);
+
+    assert(r.value > 3.9f && r.value < 4.1f);
+
+    eos_sensor_deinit();
+    printf("[PASS] sensor filter window one\n");
+}
+
+static void test_sensor_filter_default_max(void) {
+    eos_sensor_init();
+    eos_sensor_config_t cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.id = 0;
+    eos_sensor_register(&cfg);
+    assert(eos_sensor_set_filter(0, EOS_FILTER_AVERAGE, 0) == 0);
+
+    eos_sensor_reading_t r;
+    for (int i = 0; i < 10; i++)
+        eos_sensor_read_filtered(0, &r);
+
+    assert(r.value > 4.4f && r.value < 4.6f);
+
+    eos_sensor_config_t info;
+    assert(eos_sensor_get_info(0, &info) == 0);
+    assert(info.filter_window == EOS_SENSOR_FILTER_MAX_WINDOW);
+
+    eos_sensor_deinit();
+    printf("[PASS] sensor filter default max\n");
+}
+
+static void test_sensor_filter_exact_max(void) {
+    eos_sensor_init();
+    eos_sensor_config_t cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.id = 0;
+    eos_sensor_register(&cfg);
+    assert(eos_sensor_set_filter(0, EOS_FILTER_AVERAGE, EOS_SENSOR_FILTER_MAX_WINDOW) == 0);
+
+    eos_sensor_reading_t r;
+    for (int i = 0; i < 10; i++)
+        eos_sensor_read_filtered(0, &r);
+
+    assert(r.value > 4.4f && r.value < 4.6f);
+
+    eos_sensor_config_t info;
+    assert(eos_sensor_get_info(0, &info) == 0);
+    assert(info.filter_window == EOS_SENSOR_FILTER_MAX_WINDOW);
+
+    eos_sensor_deinit();
+    printf("[PASS] sensor filter exact max\n");
+}
+
+static void test_sensor_filter_invalid_window(void) {
+    eos_sensor_init();
+    eos_sensor_config_t cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.id = 0;
+    eos_sensor_register(&cfg);
+
+    assert(eos_sensor_set_filter(0, EOS_FILTER_AVERAGE, EOS_SENSOR_FILTER_MAX_WINDOW + 1) == -1);
+
+    eos_sensor_config_t info;
+    assert(eos_sensor_get_info(0, &info) == 0);
+    assert(info.filter == EOS_FILTER_NONE);
+    assert(info.filter_window == 0);
+
+    eos_sensor_deinit();
+    printf("[PASS] sensor filter invalid window\n");
+}
+
+static void test_sensor_filter_invalid_type(void) {
+    eos_sensor_init();
+    eos_sensor_config_t cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.id = 0;
+    eos_sensor_register(&cfg);
+
+    assert(eos_sensor_set_filter(0, (eos_filter_type_t)99, 3) == -1);
+
+    eos_sensor_config_t info;
+    assert(eos_sensor_get_info(0, &info) == 0);
+    assert(info.filter == EOS_FILTER_NONE);
+    assert(info.filter_window == 0);
+
+    eos_sensor_deinit();
+    printf("[PASS] sensor filter invalid type\n");
 }
 
 static void test_sensor_null(void) {
@@ -79,10 +215,17 @@ int main(void) {
     printf("=== EoS Sensor Tests ===\n");
     test_sensor_init();
     test_sensor_register();
+    test_sensor_register_invalid_filter_config();
     test_sensor_read();
     test_sensor_calibrate();
     test_sensor_filter();
+    test_sensor_filter_window();
+    test_sensor_filter_window_one();
+    test_sensor_filter_default_max();
+    test_sensor_filter_exact_max();
+    test_sensor_filter_invalid_window();
+    test_sensor_filter_invalid_type();
     test_sensor_null();
-    printf("=== ALL SENSOR TESTS PASSED (6/6) ===\n");
+    printf("=== ALL SENSOR TESTS PASSED (13/13) ===\n");
     return 0;
 }


### PR DESCRIPTION
## Overview

This PR fixes a bug in the eOS sensor service where configurable filter window sizes were accepted by the API but not actually used by the filtering logic.

The issue was in the sensor filtering path for `EOS_FILTER_AVERAGE` and `EOS_FILTER_MEDIAN`. Although `eos_sensor_set_filter()` accepted a `window_size` argument and stored it in the sensor configuration, the implementation still used a hard-coded internal window of `8` for the actual calculations.

As a result, calls such as:

```c
eos_sensor_set_filter(0, EOS_FILTER_AVERAGE, 3);
```

appeared to succeed, but the sensor filter continued to behave as if the window size were fixed.

## Issue Addressed

- The public API exposed configurable filter windows through:

```c
int eos_sensor_set_filter(uint8_t id, eos_filter_type_t filter,
                          uint8_t window_size);
```

- The sensor config also stored:

```c
uint8_t filter_window;
```

- However, the implementation ignored that value and used a fixed internal size for averaging and median filtering.

This made the API behavior inconsistent and caused incorrect filtered results for non-default window sizes.

## Documentation Alignment

While reviewing the project documentation, I found that the sensor framework describes `filter_window` as:

```c
uint8_t            filter_window;      /* Window size (1–32)  */
```

This appears in:

- `docs/book/part3-services/ch14-sensor-motor.md`

The same document also shows configurable examples such as:

```c
.filter_window = 4
```

and:

```c
eos_sensor_set_filter(0, EOS_FILTER_MEDIAN, 5);
```

Because of that, I aligned the implementation with the documentation by defining the maximum supported filter window as `32` instead of keeping the old hidden internal value of `8`.

## Proposed Approach and Implementation

The fix was implemented in the sensor service and tests.

### Code changes

- Added a named maximum filter window constant:

```c
#define EOS_SENSOR_FILTER_MAX_WINDOW 32
```

- Updated the average and median filter logic to use the configured active window instead of a hard-coded value.
- Added validation for invalid filter types.
- Added validation for oversized window values.
- Normalized `window_size == 0` to mean “use the default maximum window”.
- Reset internal filter state when the filter configuration changes.
- Enabled the sensor feature for the real sensor test target so the existing test suite builds and runs properly.

### Files changed

- `services/sensor/CMakeLists.txt`
- `services/sensor/include/eos/sensor.h`
- `services/sensor/src/sensor.c`
- `tests/test_sensor.c`

## Testing and Validation

I first reproduced the bug on the old implementation by adding a regression test and confirming it failed when the filter was set to a non-default window.

After the fix, I validated the behavior with both automated and manual testing.

### Automated test commands

```bash
cmake -B build_review -DEOS_BUILD_TESTS=ON
cmake --build build_review --target test_sensor
./build_review/tests/test_sensor
ctest --test-dir build_review -R test_sensor --output-on-failure
```

### Automated test result

```text
=== EoS Sensor Tests ===
[PASS] sensor init
[PASS] sensor register
[PASS] sensor register invalid filter config
[PASS] sensor read
[PASS] sensor calibrate
[PASS] sensor filter
[PASS] sensor filter window
[PASS] sensor filter window one
[PASS] sensor filter default max
[PASS] sensor filter exact max
[PASS] sensor filter invalid window
[PASS] sensor filter invalid type
[PASS] sensor null
=== ALL SENSOR TESTS PASSED (13/13) ===
```

### Test cases added

The updated tests now cover:

- normal average filter behavior with window `8`
- configurable average filter behavior with window `3`
- edge case with window `1`
- default/max fallback behavior when window `0` is passed
- exact upper boundary behavior at window `32`
- invalid oversized window rejection
- invalid filter type rejection
- invalid registration-time filter configuration rejection

### Manual validation

I also manually verified that different window sizes now produce different filtered values instead of behaving like a fixed window:

```text
window 1 -> final 9.00
window 3 -> final 8.00
window 32 -> final 4.50
```

(These values are based on 10 sequential test reads: 0 through 9.)

These values confirm that the implementation now honors the configured window size.

## Additional Considerations

- This PR is intentionally limited to the sensor module and its tests.
- I kept the change focused on correcting API behavior and aligning implementation with project documentation.
