### PR TITLE
fix(core): detect stale lockfile inputs

### DIFF
--- a/core/src/lockfile.c
+++ b/core/src/lockfile.c
@@ -9,6 +9,20 @@
 #include <string.h>
 #include <ctype.h>
 
+static void package_hash(const EosPackageConfig *pc, char *hash) {
+    if (pc->hash[0]) {
+        strncpy(hash, pc->hash, EOS_HASH_LEN - 1);
+        hash[EOS_HASH_LEN - 1] = '\0';
+        return;
+    }
+
+    char input[2048];
+    snprintf(input, sizeof(input), "%s:%s:%s:%s",
+             pc->name, pc->version, pc->source,
+             eos_build_type_str(pc->build_type));
+    eos_cache_compute_hash(input, strlen(input), hash, EOS_HASH_LEN);
+}
+
 EosResult eos_lockfile_generate(EosLockfile *lock, const EosConfig *cfg) {
     memset(lock, 0, sizeof(*lock));
     strncpy(lock->project_name, cfg->project.name, EOS_MAX_NAME - 1);
@@ -22,17 +36,8 @@ EosResult eos_lockfile_generate(EosLockfile *lock, const EosConfig *cfg) {
         strncpy(entry->version, pc->version, EOS_MAX_NAME - 1);
         strncpy(entry->resolved_version, pc->version, EOS_MAX_NAME - 1);
         strncpy(entry->source, pc->source, EOS_MAX_URL - 1);
-        strncpy(entry->hash, pc->hash, EOS_HASH_LEN - 1);
         entry->build_type = pc->build_type;
-
-        /* If no hash provided, compute one from metadata */
-        if (!entry->hash[0]) {
-            char input[2048];
-            snprintf(input, sizeof(input), "%s:%s:%s:%s",
-                     entry->name, entry->version,
-                     entry->source, eos_build_type_str(entry->build_type));
-            eos_cache_compute_hash(input, strlen(input), entry->hash, EOS_HASH_LEN);
-        }
+        package_hash(pc, entry->hash);
 
         lock->count++;
     }
@@ -138,13 +143,26 @@ EosResult eos_lockfile_load(EosLockfile *lock, const char *path) {
 
 int eos_lockfile_is_current(const EosLockfile *lock, const EosConfig *cfg) {
     if (strcmp(lock->project_name, cfg->project.name) != 0) return 0;
+    if (strcmp(lock->project_version, cfg->project.version) != 0) return 0;
     if (lock->count != cfg->package_count) return 0;
 
+    int matched[EOS_MAX_PACKAGES] = {0};
     for (int i = 0; i < cfg->package_count; i++) {
+        const EosPackageConfig *pc = &cfg->packages[i];
+        char expected_hash[EOS_HASH_LEN] = {0};
+        package_hash(pc, expected_hash);
+
         int found = 0;
         for (int j = 0; j < lock->count; j++) {
-            if (strcmp(cfg->packages[i].name, lock->entries[j].name) == 0 &&
-                strcmp(cfg->packages[i].version, lock->entries[j].version) == 0) {
+            const EosLockEntry *entry = &lock->entries[j];
+            if (!matched[j] &&
+                strcmp(pc->name, entry->name) == 0 &&
+                strcmp(pc->version, entry->version) == 0 &&
+                strcmp(pc->version, entry->resolved_version) == 0 &&
+                strcmp(pc->source, entry->source) == 0 &&
+                strcmp(expected_hash, entry->hash) == 0 &&
+                pc->build_type == entry->build_type) {
+                matched[j] = 1;
                 found = 1;
                 break;
             }

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "eos/config.h"
+#include "eos/lockfile.h"
 #include "eos/log.h"
 
 static int tests_run = 0;
@@ -100,6 +101,70 @@ static void test_config_missing_file(void) {
     ASSERT(res == EOS_ERR_IO, "returns IO error for missing file");
 }
 
+static void test_lockfile_freshness(void) {
+    printf("test_lockfile_freshness:\n");
+    static EosConfig cfg;
+    static EosLockfile lock;
+
+    eos_config_init(&cfg);
+    snprintf(cfg.project.name, sizeof(cfg.project.name), "%s", "demo");
+    snprintf(cfg.project.version, sizeof(cfg.project.version), "%s", "1.0.0");
+    cfg.package_count = 2;
+
+    snprintf(cfg.packages[0].name, sizeof(cfg.packages[0].name), "%s", "alpha");
+    snprintf(cfg.packages[0].version, sizeof(cfg.packages[0].version), "%s", "1.2.3");
+    snprintf(cfg.packages[0].source, sizeof(cfg.packages[0].source), "%s", "https://example.com/alpha.tar.gz");
+    snprintf(cfg.packages[0].hash, sizeof(cfg.packages[0].hash), "%s", "explicit-checksum");
+    cfg.packages[0].build_type = EOS_BUILD_CMAKE;
+
+    snprintf(cfg.packages[1].name, sizeof(cfg.packages[1].name), "%s", "beta");
+    snprintf(cfg.packages[1].version, sizeof(cfg.packages[1].version), "%s", "4.5.6");
+    snprintf(cfg.packages[1].source, sizeof(cfg.packages[1].source), "%s", "https://example.com/beta.tar.gz");
+    cfg.packages[1].build_type = EOS_BUILD_MAKE;
+
+    ASSERT(eos_lockfile_generate(&lock, &cfg) == EOS_OK, "lockfile generates");
+    ASSERT(eos_lockfile_is_current(&lock, &cfg), "generated lockfile is current");
+
+    EosLockEntry tmp = lock.entries[0];
+    lock.entries[0] = lock.entries[1];
+    lock.entries[1] = tmp;
+    ASSERT(eos_lockfile_is_current(&lock, &cfg), "package order does not affect freshness");
+    tmp = lock.entries[0];
+    lock.entries[0] = lock.entries[1];
+    lock.entries[1] = tmp;
+
+    snprintf(cfg.project.version, sizeof(cfg.project.version), "%s", "2.0.0");
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "project version change is stale");
+    snprintf(cfg.project.version, sizeof(cfg.project.version), "%s", "1.0.0");
+
+    snprintf(cfg.packages[0].name, sizeof(cfg.packages[0].name), "%s", "renamed-alpha");
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "package name change is stale");
+    snprintf(cfg.packages[0].name, sizeof(cfg.packages[0].name), "%s", "alpha");
+
+    snprintf(cfg.packages[0].version, sizeof(cfg.packages[0].version), "%s", "1.2.4");
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "requested version change is stale");
+    snprintf(cfg.packages[0].version, sizeof(cfg.packages[0].version), "%s", "1.2.3");
+
+    snprintf(cfg.packages[0].source, sizeof(cfg.packages[0].source), "%s", "https://example.com/alpha-v2.tar.gz");
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "package source change is stale");
+    snprintf(cfg.packages[0].source, sizeof(cfg.packages[0].source), "%s", "https://example.com/alpha.tar.gz");
+
+    snprintf(cfg.packages[0].hash, sizeof(cfg.packages[0].hash), "%s", "new-checksum");
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "explicit checksum change is stale");
+    snprintf(cfg.packages[0].hash, sizeof(cfg.packages[0].hash), "%s", "explicit-checksum");
+
+    cfg.packages[0].build_type = EOS_BUILD_MAKE;
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "build type change is stale");
+    cfg.packages[0].build_type = EOS_BUILD_CMAKE;
+
+    snprintf(lock.entries[0].resolved_version, sizeof(lock.entries[0].resolved_version), "%s", "1.2.4");
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "resolved version change is stale");
+    snprintf(lock.entries[0].resolved_version, sizeof(lock.entries[0].resolved_version), "%s", "1.2.3");
+
+    lock.entries[1].hash[0] ^= 1;
+    ASSERT(!eos_lockfile_is_current(&lock, &cfg), "generated checksum change is stale");
+}
+
 int main(void) {
     eos_log_set_level(EOS_LOG_ERROR);
 
@@ -108,6 +173,7 @@ int main(void) {
     test_config_init();
     test_config_load();
     test_config_missing_file();
+    test_lockfile_freshness();
 
     printf("\n=== Results: %d/%d passed ===\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;


### PR DESCRIPTION
## Problem

`eos_lockfile_is_current()` only compared project name, package count, package name, and requested version. Changes to project version, resolved version, source URL, checksum, or build type could therefore leave a stale lockfile marked current, weakening reproducible-build guarantees.

## Approach

- Reuse one helper for explicit checksums and generated metadata checksums.
- Compare project version and every serialized package input.
- Match entries one-to-one without depending on package order.
- Add regressions for project version, package name, requested/resolved versions, source, explicit/generated checksums, build type, and reordered entries.

Public signatures and the lockfile format are unchanged.

## Validation

- Regression before fix: **failed as expected**; changed lockfile inputs were incorrectly accepted as current.
- Release CMake build: **passed**.
- Targeted `test_config`: **passed**.
- Full CTest: **21/21 passed**.
- `python3 -m pytest tests -q`: **10 passed**.
- ASan/UBSan `test_config`: **passed**.
- `git diff --check`: **passed**.
- Independent review: **approved with no findings** after adding missing name/requested-version regression coverage.

## Additional considerations

The host Release build emits existing warnings in unrelated tests; neither changed C file adds a warning. No migration is needed because the serialized format is unchanged—existing stale lockfiles will simply be regenerated when their inputs differ.

GitHub Actions created Python, build, simulation, CodeQL, and assignment runs for this PR, but all are currently `action_required` pending maintainer approval.
