### PR TITLE
fix(tests): stop test_package overflowing the stack on small-stack hosts

### DIFF
--- a/tests/test_package.c
+++ b/tests/test_package.c
@@ -9,8 +9,15 @@ static int passed = 0;
 
 static int dummy_init(void) { return 0; }
 
+/* EosPackageSet is EOS_MAX_PACKAGES * sizeof(EosPackage) = ~3.8 MB, which
+ * overflows the 1 MB default thread stack on Windows and on any other
+ * small-stack host, crashing these tests before main() gets to run them.
+ * Every set below is therefore static, matching how cmd/eos/main.c declares
+ * the same type. Each test memsets its set on entry, so nothing carries
+ * over between tests. */
+
 static void test_package_register(void) {
-    EosPackageSet set;
+    static EosPackageSet set;
     memset(&set, 0, sizeof(set));
     EosPackage pkg;
     memset(&pkg, 0, sizeof(pkg));
@@ -24,7 +31,7 @@ static void test_package_register(void) {
 }
 
 static void test_package_find(void) {
-    EosPackageSet set;
+    static EosPackageSet set;
     memset(&set, 0, sizeof(set));
     EosPackage pkg;
     memset(&pkg, 0, sizeof(pkg));
@@ -39,7 +46,7 @@ static void test_package_find(void) {
 }
 
 static void test_package_find_not_found(void) {
-    EosPackageSet set;
+    static EosPackageSet set;
     memset(&set, 0, sizeof(set));
     const EosPackage *found = eos_package_find(&set, "nonexistent");
     assert(found == NULL);
@@ -53,7 +60,7 @@ static void test_package_find_null(void) {
 }
 
 static void test_package_register_multiple(void) {
-    EosPackageSet set;
+    static EosPackageSet set;
     memset(&set, 0, sizeof(set));
     EosPackage p1, p2, p3;
     memset(&p1, 0, sizeof(p1));
@@ -76,7 +83,7 @@ static void test_package_register_multiple(void) {
 }
 
 static void test_package_init_all(void) {
-    EosPackageSet set;
+    static EosPackageSet set;
     memset(&set, 0, sizeof(set));
     EosPackage pkg;
     memset(&pkg, 0, sizeof(pkg));
@@ -90,7 +97,7 @@ static void test_package_init_all(void) {
 }
 
 static void test_package_build_type(void) {
-    EosPackageSet set;
+    static EosPackageSet set;
     memset(&set, 0, sizeof(set));
     EosPackage pkg;
     memset(&pkg, 0, sizeof(pkg));


### PR DESCRIPTION
## Summary

`test_package` crashes on Windows before it can run a single assertion. The
cause is a stack overflow: `EosPackageSet` is ~3.8 MB and six of the seven test
functions declared one as an ordinary stack local. Linux's 8 MB default stack
absorbs it, which is why CI has never seen this; Windows gives a thread 1 MB.

## Type of Change

- [x] fix — Bug fix
- [x] test — Add or fix tests

## Changes

- `tests/test_package.c` — declare the six `EosPackageSet` locals `static`, and
  document why in one comment at the top of the file.

## The defect

ctest reports a bare SEGFAULT with no output, since the fault happens on entry
to the first test:

```
21/21 Test #21: test_package .....................***Exception: SegFault
```

gdb puts the fault in the stack-probe helper, which is the signature of a stack
overflow rather than a bad pointer:

```
Thread 1 received signal SIGSEGV, Segmentation fault.
#0  ___chkstk_ms ()
#1  test_package_register ()
#2  main ()
```

The size is the whole story. `EosPackageSet` embeds `EOS_MAX_PACKAGES` (128)
`EosPackage` entries at 31072 bytes each:

```
EosPackage=31072  EosPackageSet=3977224 bytes (3.79 MB)
```

3.79 MB against a 1 MB stack faults immediately and unconditionally.

## Approach

Declare the sets `static`.

This is not an arbitrary choice — it is the convention the codebase already
uses. Production code in `cmd/eos/main.c` declares `static EosConfig` and
`static EosPackageSet` at all eleven sites it touches these types. Whoever wrote
that already knew these structs are too large for the stack; the tests are the
only place that omits it, and the tests are exactly where it crashes.

`static` is safe here because every affected function already begins with
`memset(&set, 0, sizeof(set))`. Re-initialization is explicit and
unconditional, so no state carries between tests and no test ordering
dependency is introduced. I verified all six sites individually rather than
assuming.

## Testing

- [x] Unit tests pass
- [x] New tests added for new functionality — n/a, this repairs an existing test

Native build, GCC 15.2 (MinGW-w64), `-DEOS_BUILD_TESTS=ON`:

| | Before | After |
|---|---|---|
| `test_package` | SIGSEGV, 0 assertions run | all 7 pass |
| Full suite | 20/21 | **21/21** |

```
=== EoS Package Tests ===
[PASS] package register
[PASS] package find
[PASS] package find not found
[PASS] package find null set
[PASS] package register multiple
[PASS] package init all
[PASS] package build type

=== ALL 7 PACKAGE TESTS PASSED ===
```

The test itself is the regression test: on any 1 MB-stack host it fails before
this change and passes after, with no new test scaffolding required.

## Considerations and limitations

- **This fixes the crash, not the underlying design question.** A ~3.8 MB
  by-value struct is worth a second look in a project whose target is embedded
  systems, where a task stack is measured in kilobytes rather than megabytes.
  Anything that puts an `EosPackageSet` on a thread stack will fault on real
  hardware far more readily than it does on a desktop. The host tooling
  (`cmd/eos`) can afford `static`; a device may not be able to afford the object
  at all.
- **I deliberately kept that out of this PR.** Shrinking `EosPackage`, reducing
  `EOS_MAX_PACKAGES`, or moving to a caller-provided/heap allocation are all
  public-API changes with real ABI consequences, and they should be a designed
  decision by the maintainers rather than a side effect of a test fix. Glad to
  open a separate issue to discuss it if that is useful.
- **Why CI did not catch this:** the crash needs a stack smaller than 3.8 MB, so
  it is invisible to Linux runners at default limits. A Windows job, or
  `ulimit -s 1024` on the existing Linux job, would surface it.

## Pre-Submission Checklist

- [x] Code compiles without warnings — no new warnings introduced
- [x] All existing tests pass — 21/21, up from 20/21
- [x] New tests added for new functionality — n/a, this repairs an existing test
- [x] Documentation updated if API changed — n/a, no API change
- [x] Commit message follows `<type>(<scope>): <description>`
- [x] Branch is rebased on latest master (0 commits behind)

## Related Issues

None. Found while building and running the suite on Windows.
