### PR TITLE
fix(devicetree): bounds-check untrusted DTB input; enable the dead fuzz target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 - **`eos_queue_create`:** Size check now uses division so `item_size * capacity` cannot wrap `size_t` on 32-bit targets and overflow the 1024-byte queue store.
 - **`eos_sem_create`:** Reject `initial > max` and `max` values that do not fit in `int32_t`, so the counting-semaphore invariant cannot be created already broken.
 - **`eos_mutex_lock`:** Recursive lock returns `EOS_KERN_FULL` at `uint8_t` saturation instead of wrapping `rec_count` to 0 and leaving the mutex stuck.
+- **`eos_dt_parse`:** Bounds-check the flattened device tree blob before dereferencing it. A malformed DTB could previously read outside the buffer four different ways: `off_struct` past the end of the blob (the `size - off_struct` bound wrapped), a node name with no terminator (unbounded `strlen`), a property name offset outside the strings block, and nesting deeper than the 32-entry node stack. All are now rejected.
+- **`eos_dt_find_compatible`:** Search within `prop->len` instead of calling `strstr()` on a property value that is not guaranteed to be NUL-terminated.
+- **`eos_dt_get_irq`:** Reject a negative index, and one large enough that `index * 4` overflows, before it is used as an offset.
+
+### Added
+- `tests/test_devicetree.c` — device tree parser suite: happy path, malformed-blob rejection, a sweep over every truncation of a valid blob, and a single-byte corruption sweep.
+- `tests/fuzz/` is now wired into the build. The directory was never added by any `add_subdirectory`, so no fuzz target could be built. `fuzz_devicetree` is enabled and calls the real `eos_dt_parse()` API — it previously declared a non-existent `eos_dtb_parse()` and was commented out.
 
 ## [3.0.1] - 2026-05-16
 

--- a/docs/security-hardening-guide.md
+++ b/docs/security-hardening-guide.md
@@ -255,6 +255,41 @@ if (remaining < EOS_STACK_CRITICAL_THRESHOLD) {
 
 ---
 
+## 13. Parsing Untrusted Binary Input
+
+A flattened device tree is not trusted input. It arrives from a prior boot
+stage or a flash region, and every offset and length inside the blob is chosen
+by whoever produced it. `eos_dt_parse()` therefore validates before it
+dereferences:
+
+- `totalsize` may not exceed the buffer length passed in, and the struct and
+  strings blocks must both begin inside the blob. Without this the
+  `size - off_struct` arithmetic wraps and the walk runs off the end.
+- Every token, property length and property name offset is bounds-checked
+  against its block before it is read.
+- Node names and property names must be NUL-terminated inside the blob;
+  an unterminated name is rejected rather than passed to `strlen()`.
+- Nesting deeper than `EOS_DT_MAX_DEPTH` is rejected rather than walking past
+  the parser's own node stack.
+- Property values are raw bytes and are not assumed to be NUL-terminated.
+  `eos_dt_find_compatible()` searches within `prop->len` instead of calling
+  `strstr()` on the buffer.
+
+Regression coverage lives in `tests/test_devicetree.c`, which sweeps every
+truncation of a valid blob and every single-byte corruption of it. A libFuzzer
+target is available for deeper coverage:
+
+```bash
+cmake -B build -DEOS_BUILD_TESTS=ON -DEOS_ENABLE_FUZZING=ON \
+      -DCMAKE_C_COMPILER=clang
+cmake --build build --target fuzz_devicetree
+./build/tests/fuzz/fuzz_devicetree -max_total_time=60
+```
+
+Apply the same rules to any new parser that consumes off-device data: validate
+offsets against the buffer you were actually handed, never trust a length field,
+and never assume a byte range is NUL-terminated.
+
 ## Production Build Checklist
 
 Use this checklist before releasing a production firmware image:
@@ -274,3 +309,4 @@ Use this checklist before releasing a production firmware image:
 - [ ] `EOS_LOG_LEVEL` is `EOS_LOG_ERROR` or `EOS_LOG_NONE`
 - [ ] Rollback protection counter is set correctly
 - [ ] SBOM is generated and archived for this build
+- [ ] Parsers for off-device input are fuzzed (see section 13)

--- a/drivers/devicetree/devicetree.c
+++ b/drivers/devicetree/devicetree.c
@@ -11,99 +11,212 @@ static uint32_t be32(const uint8_t *p) {
            ((uint32_t)p[2] << 8)  | (uint32_t)p[3];
 }
 
-static uint32_t align4(uint32_t v) { return (v + 3) & ~3u; }
+/* ------------------------------------------------------------------
+ * Bounds-checked primitives
+ *
+ * Everything below treats the blob as untrusted. A flattened device tree
+ * usually arrives from a prior boot stage or a flash region, so every offset
+ * and length it contains has to be validated against the buffer we were
+ * actually handed before it is used to index into it.
+ * ------------------------------------------------------------------ */
 
-int eos_dt_parse(EosDeviceTree *dt, const uint8_t *dtb, uint32_t size) {
-    if (!dt || !dtb || size < 40) return -1;
+/* Round `v` up to a 4-byte boundary, refusing the cases where that wraps. */
+static int dt_align4(uint32_t v, uint32_t *out)
+{
+    if (v > UINT32_MAX - 3u) return -1;
+    *out = (v + 3u) & ~3u;
+    return 0;
+}
+
+/* Read a big-endian u32 at `off`, provided all four bytes are inside `len`. */
+static int dt_read_be32(const uint8_t *buf, uint32_t len, uint32_t off,
+                        uint32_t *out)
+{
+    if (off > len || len - off < 4u) return -1;
+    *out = be32(buf + off);
+    return 0;
+}
+
+/* Length of the NUL-terminated string at `off`, without reading past `len`.
+ * Returns -1 when the buffer ends before a terminator is found. */
+static int dt_strlen_at(const uint8_t *buf, uint32_t len, uint32_t off,
+                        uint32_t *out)
+{
+    if (off >= len) return -1;
+    for (uint32_t i = off; i < len; i++) {
+        if (buf[i] == '\0') { *out = i - off; return 0; }
+    }
+    return -1;
+}
+
+/* Copy a bounded, possibly unterminated byte range into a NUL-terminated
+ * destination buffer. */
+static void dt_copy_str(char *dst, uint32_t dst_sz, const uint8_t *src,
+                        uint32_t src_len)
+{
+    uint32_t n = (src_len < dst_sz - 1u) ? src_len : dst_sz - 1u;
+    memcpy(dst, src, n);
+    dst[n] = '\0';
+}
+
+/* Cache a string-valued root property. The stored value is only `prop->len`
+ * bytes and is not guaranteed to be terminated, so stop at whichever comes
+ * first: an embedded NUL, the property length, or the destination size. */
+static void dt_cache_string_prop(char *dst, uint32_t dst_sz,
+                                 const EosDtProp *prop)
+{
+    uint32_t n = prop->len;
+    uint32_t i = 0;
+    while (i < n && prop->data[i] != '\0') i++;
+    dt_copy_str(dst, dst_sz, prop->data, i);
+}
+
+int eos_dt_parse(EosDeviceTree *dt, const uint8_t *dtb, uint32_t size)
+{
+    if (!dt || !dtb || size < EOS_DT_HEADER_SIZE) return -1;
     memset(dt, 0, sizeof(*dt));
 
-    uint32_t magic = be32(dtb);
-    if (magic != EOS_DT_MAGIC) return -1;
+    if (be32(dtb) != EOS_DT_MAGIC) return -1;
 
-    uint32_t totalsize  = be32(dtb + 4);
-    uint32_t off_struct = be32(dtb + 8);
-    uint32_t off_string = be32(dtb + 12);
-    dt->version   = be32(dtb + 20);
+    uint32_t totalsize   = be32(dtb + 4);
+    uint32_t off_struct  = be32(dtb + 8);
+    uint32_t off_string  = be32(dtb + 12);
+    uint32_t size_string = be32(dtb + 32);
+    uint32_t size_struct = be32(dtb + 36);
+
+    dt->version    = be32(dtb + 20);
     dt->boot_cpuid = be32(dtb + 28);
-    (void)totalsize;
+
+    /* The blob may sit inside a larger buffer, but it must never claim to be
+     * larger than the buffer we were given. */
+    uint32_t blob_len = size;
+    if (totalsize > blob_len) return -1;
+    if (totalsize >= EOS_DT_HEADER_SIZE) blob_len = totalsize;
+
+    /* Both blocks have to begin inside the blob. Without this the subtraction
+     * below wraps and the walk runs off the end of the buffer. */
+    if (off_struct >= blob_len || off_string >= blob_len) return -1;
 
     const uint8_t *structs = dtb + off_struct;
     const uint8_t *strings = dtb + off_string;
-    uint32_t pos = 0;
 
-    EosDtNode *stack[32];
-    int depth = 0;
+    /* Honour the declared block sizes when they fit, otherwise clamp to the
+     * rest of the blob. Either way the walk stays inside the buffer. */
+    uint32_t struct_len = blob_len - off_struct;
+    uint32_t string_len = blob_len - off_string;
+    if (size_struct != 0 && size_struct < struct_len) struct_len = size_struct;
+    if (size_string != 0 && size_string < string_len) string_len = size_string;
 
-    while (pos < (size - off_struct)) {
-        uint32_t token = be32(structs + pos);
+    EosDtNode *stack[EOS_DT_MAX_DEPTH];
+    uint32_t depth = 0;
+    uint32_t pos   = 0;
+
+    /* `pos` advances by at least 4 on every iteration and every read is bounds
+     * checked against `struct_len`, so this terminates on any input. */
+    for (;;) {
+        uint32_t token;
+        if (dt_read_be32(structs, struct_len, pos, &token) != 0) return -1;
         pos += 4;
 
         switch (token) {
         case EOS_DT_BEGIN_NODE: {
+            uint32_t name_len;
+            if (dt_strlen_at(structs, struct_len, pos, &name_len) != 0)
+                return -1;
+
+            uint32_t adv;
+            if (dt_align4(name_len + 1u, &adv) != 0) return -1;
+            if (adv > struct_len - pos) return -1;
+
             if (dt->node_count >= EOS_DT_MAX_NODES) return -1;
+            if (depth >= EOS_DT_MAX_DEPTH) return -1;
+
             EosDtNode *node = &dt->nodes[dt->node_count++];
             memset(node, 0, sizeof(*node));
-
-            const char *name = (const char *)(structs + pos);
-            strncpy(node->name, name, EOS_DT_NAME_MAX - 1);
-            pos += align4((uint32_t)strlen(name) + 1);
+            dt_copy_str(node->name, sizeof(node->name), structs + pos, name_len);
 
             if (depth == 0) {
                 dt->root = node;
                 node->parent = NULL;
             } else {
-                node->parent = stack[depth - 1];
                 EosDtNode *parent = stack[depth - 1];
-                if (parent->child_count < 16)
+                node->parent = parent;
+                if (parent->child_count < EOS_DT_MAX_CHILDREN)
                     parent->children[parent->child_count++] = node;
             }
-            if (depth < 32) stack[depth] = node;
-            depth++;
+            stack[depth++] = node;
+
+            pos += adv;
             break;
         }
+
         case EOS_DT_END_NODE:
-            if (depth > 0) depth--;
+            /* A close with nothing open means the blob is malformed. */
+            if (depth == 0) return -1;
+            depth--;
             break;
 
         case EOS_DT_PROP: {
-            uint32_t len     = be32(structs + pos); pos += 4;
-            uint32_t nameoff = be32(structs + pos); pos += 4;
-            if (depth == 0) { pos += align4(len); break; }
+            uint32_t len, nameoff;
+            if (dt_read_be32(structs, struct_len, pos, &len) != 0) return -1;
+            pos += 4;
+            if (dt_read_be32(structs, struct_len, pos, &nameoff) != 0) return -1;
+            pos += 4;
 
-            EosDtNode *node = stack[depth - 1];
-            if (node->prop_count < EOS_DT_MAX_PROPS) {
-                EosDtProp *prop = &node->props[node->prop_count++];
+            /* The value, and its 4-byte-aligned padding, must lie inside the
+             * struct block. */
+            uint32_t adv;
+            if (len > struct_len - pos) return -1;
+            if (dt_align4(len, &adv) != 0) return -1;
+            if (adv > struct_len - pos) return -1;
+
+            if (depth > 0) {
+                /* The name lives in the strings block at an offset the blob
+                 * chose, so it needs validating before it is dereferenced. */
+                uint32_t pname_len;
+                if (dt_strlen_at(strings, string_len, nameoff, &pname_len) != 0)
+                    return -1;
                 const char *pname = (const char *)(strings + nameoff);
-                strncpy(prop->name, pname, EOS_DT_NAME_MAX - 1);
-                uint32_t clen = (len > EOS_DT_PROP_MAX) ? EOS_DT_PROP_MAX : len;
-                memcpy(prop->data, structs + pos, clen);
-                prop->len = clen;
 
-                /* Cache model and compatible at root level */
-                if (depth == 1) {
-                    if (strcmp(pname, "model") == 0) {
-                        strncpy(dt->model, (const char *)prop->data, 63);
-                        dt->model[63] = '\0';
-                    } else if (strcmp(pname, "compatible") == 0) {
-                        strncpy(dt->compatible, (const char *)prop->data, 127);
-                        dt->compatible[127] = '\0';
+                EosDtNode *node = stack[depth - 1];
+                if (node->prop_count < EOS_DT_MAX_PROPS) {
+                    EosDtProp *prop = &node->props[node->prop_count++];
+                    dt_copy_str(prop->name, sizeof(prop->name),
+                                (const uint8_t *)pname, pname_len);
+
+                    uint32_t clen = (len > EOS_DT_PROP_MAX) ? EOS_DT_PROP_MAX : len;
+                    memcpy(prop->data, structs + pos, clen);
+                    prop->len = clen;
+
+                    /* Cache model and compatible at root level */
+                    if (depth == 1) {
+                        if (strcmp(pname, "model") == 0) {
+                            dt_cache_string_prop(dt->model, sizeof(dt->model), prop);
+                        } else if (strcmp(pname, "compatible") == 0) {
+                            dt_cache_string_prop(dt->compatible,
+                                                 sizeof(dt->compatible), prop);
+                        }
                     }
+                    if (strcmp(pname, "phandle") == 0 && prop->len >= 4)
+                        node->phandle = be32(prop->data);
                 }
-                if (strcmp(pname, "phandle") == 0 && len >= 4)
-                    node->phandle = be32(prop->data);
             }
-            pos += align4(len);
+
+            pos += adv;
             break;
         }
+
         case EOS_DT_NOP:
             break;
+
         case EOS_DT_END:
-            return 0;
+            /* Every node that was opened must have been closed. */
+            return (depth == 0) ? 0 : -1;
+
         default:
             return -1;
         }
     }
-    return 0;
 }
 
 EosDtNode *eos_dt_find(EosDeviceTree *dt, const char *path) {
@@ -136,12 +249,27 @@ EosDtNode *eos_dt_find(EosDeviceTree *dt, const char *path) {
     return current;
 }
 
+/* Substring search restricted to `prop->len`.
+ *
+ * A property value is raw bytes, and a value that filled the property buffer
+ * has no terminator, so strstr() would run past the end of prop->data. */
+static int dt_prop_contains(const EosDtProp *prop, const char *needle)
+{
+    size_t nlen = strlen(needle);
+    if (nlen == 0) return 1;
+    if (prop->len < nlen) return 0;
+    for (uint32_t i = 0; i + nlen <= prop->len; i++) {
+        if (memcmp(prop->data + i, needle, nlen) == 0) return 1;
+    }
+    return 0;
+}
+
 EosDtNode *eos_dt_find_compatible(EosDeviceTree *dt, const char *compat) {
     if (!dt || !compat) return NULL;
     for (int i = 0; i < dt->node_count; i++) {
         for (int j = 0; j < dt->nodes[i].prop_count; j++) {
             if (strcmp(dt->nodes[i].props[j].name, "compatible") == 0) {
-                if (strstr((const char *)dt->nodes[i].props[j].data, compat))
+                if (dt_prop_contains(&dt->nodes[i].props[j], compat))
                     return &dt->nodes[i];
             }
         }
@@ -194,9 +322,11 @@ int eos_dt_get_reg(EosDtNode *node, uint32_t *addr, uint32_t *size) {
 
 int eos_dt_get_irq(EosDtNode *node, int index) {
     const EosDtProp *p = eos_dt_get_prop(node, "interrupts");
-    if (!p) return -1;
-    uint32_t offset = (uint32_t)(index * 4);
-    if (offset + 4 > p->len) return -1;
+    /* A negative index, or one large enough that index * 4 overflows, must be
+     * rejected before it is turned into an offset. */
+    if (!p || index < 0 || index > (int)(UINT32_MAX / 4u)) return -1;
+    uint32_t offset = (uint32_t)index * 4u;
+    if (offset > p->len || p->len - offset < 4u) return -1;
     return (int)be32(p->data + offset);
 }
 

--- a/drivers/devicetree/devicetree.h
+++ b/drivers/devicetree/devicetree.h
@@ -13,8 +13,16 @@ extern "C" {
 
 #define EOS_DT_MAX_NODES       128
 #define EOS_DT_MAX_PROPS       16
+#define EOS_DT_MAX_CHILDREN    16
 #define EOS_DT_NAME_MAX        64
 #define EOS_DT_PROP_MAX        256
+
+/* Deepest node nesting the parser will follow. A blob nested deeper than this
+ * is rejected rather than silently walking off the end of the node stack. */
+#define EOS_DT_MAX_DEPTH       32
+
+/* Size of the flattened device tree header, in bytes. */
+#define EOS_DT_HEADER_SIZE     40
 
 #define EOS_DT_MAGIC           0xD00DFEED
 #define EOS_DT_BEGIN_NODE      0x00000001
@@ -34,7 +42,7 @@ typedef struct eos_dt_node {
     EosDtProp             props[EOS_DT_MAX_PROPS];
     int                   prop_count;
     struct eos_dt_node   *parent;
-    struct eos_dt_node   *children[16];
+    struct eos_dt_node   *children[EOS_DT_MAX_CHILDREN];
     int                   child_count;
     uint32_t              phandle;
 } EosDtNode;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,3 +131,12 @@ target_include_directories(test_package PRIVATE
 )
 target_link_libraries(test_package PRIVATE eos_pkg eos_core)
 add_test(NAME test_package COMMAND test_package)
+
+# --- test_devicetree: Flattened device tree parser ---
+add_executable(test_devicetree test_devicetree.c)
+target_link_libraries(test_devicetree PRIVATE eos_devicetree)
+add_test(NAME test_devicetree COMMAND test_devicetree)
+
+# --- Fuzz targets ---
+# Opt-in (-DEOS_ENABLE_FUZZING=ON, Clang only); the subdirectory guards itself.
+add_subdirectory(fuzz)

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -27,13 +27,12 @@ if(EOS_ENABLE_FUZZING)
         LINK_FLAGS "${FUZZ_FLAGS}"
     )
 
-    # These require the parser libraries to be linked
-    # add_executable(fuzz_devicetree fuzz_devicetree.c)
-    # target_link_libraries(fuzz_devicetree PRIVATE eos_devicetree)
-    # set_target_properties(fuzz_devicetree PROPERTIES
-    #     COMPILE_FLAGS "${FUZZ_FLAGS}"
-    #     LINK_FLAGS "${FUZZ_FLAGS}"
-    # )
+    add_executable(fuzz_devicetree fuzz_devicetree.c)
+    target_link_libraries(fuzz_devicetree PRIVATE eos_devicetree)
+    set_target_properties(fuzz_devicetree PROPERTIES
+        COMPILE_FLAGS "${FUZZ_FLAGS}"
+        LINK_FLAGS "${FUZZ_FLAGS}"
+    )
 
     # add_executable(fuzz_ota_header fuzz_ota_header.c)
     # target_link_libraries(fuzz_ota_header PRIVATE eos_ota)
@@ -42,5 +41,5 @@ if(EOS_ENABLE_FUZZING)
     #     LINK_FLAGS "${FUZZ_FLAGS}"
     # )
 
-    message(STATUS "  Fuzz targets: fuzz_sha256, fuzz_aes")
+    message(STATUS "  Fuzz targets: fuzz_sha256, fuzz_aes, fuzz_devicetree")
 endif()

--- a/tests/fuzz/fuzz_devicetree.c
+++ b/tests/fuzz/fuzz_devicetree.c
@@ -3,17 +3,33 @@
 
 /**
  * @file fuzz_devicetree.c
- * @brief libFuzzer harness for device tree parser
+ * @brief libFuzzer harness for the flattened device tree parser
+ *
+ * A DTB is untrusted input: it arrives from a prior boot stage or a flash
+ * region and every offset and length inside it is attacker-influenced. The
+ * parser must reject anything malformed without reading outside the blob.
+ *
+ * Build and run:
+ *   cmake -B build -DEOS_BUILD_TESTS=ON -DEOS_ENABLE_FUZZING=ON \
+ *         -DCMAKE_C_COMPILER=clang
+ *   ./build/tests/fuzz/fuzz_devicetree -max_total_time=60
  */
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
-/* Forward-declare the DTB parse function */
-extern int eos_dtb_parse(const void *dtb, size_t len);
+#include "devicetree.h"
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    /* Feed arbitrary data to the DTB parser — should never crash */
-    eos_dtb_parse(data, size);
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    /* The parser takes a uint32_t length; skip inputs it could not describe. */
+    if (size > UINT32_MAX) return 0;
+
+    /* libFuzzer's own buffer ends exactly at `size` and is redzoned by ASan,
+     * so a one-byte over-read of the blob is reported rather than tolerated.
+     * The output tree is static only to keep it off the (limited) stack —
+     * eos_dt_parse() memsets it before touching anything. */
+    static EosDeviceTree dt;
+    (void)eos_dt_parse(&dt, data, (uint32_t)size);
     return 0;
 }

--- a/tests/test_devicetree.c
+++ b/tests/test_devicetree.c
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EoS Project
+// ISO/IEC 25000 | ISO/IEC/IEEE 15288:2023
+
+/**
+ * @file test_devicetree.c
+ * @brief Flattened device tree parser: happy path and malformed-blob rejection
+ *
+ * A DTB reaches us from a prior boot stage or a flash region, so every offset
+ * and length inside it is untrusted input. The "malformed" cases below are
+ * regressions: each one used to read outside the blob (or outside the parser's
+ * own node stack) before the bounds checks were added. Running this suite under
+ * -fsanitize=address,undefined reproduces the original reports.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "devicetree.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT(expr, msg)                                         \
+    do {                                                          \
+        tests_run++;                                              \
+        if (!(expr)) {                                            \
+            printf("  FAIL: %s (line %d)\n", msg, __LINE__);      \
+        } else {                                                  \
+            tests_passed++;                                       \
+            printf("  PASS: %s\n", msg);                          \
+        }                                                         \
+    } while (0)
+
+/* ------------------------------------------------------------------
+ * Minimal DTB builder
+ * ------------------------------------------------------------------ */
+
+typedef struct {
+    uint8_t  buf[1024];
+    uint32_t len;
+} Blob;
+
+static void b_reset(Blob *b) { b->len = 0; }
+
+static void b_u32(Blob *b, uint32_t v)
+{
+    b->buf[b->len++] = (uint8_t)(v >> 24);
+    b->buf[b->len++] = (uint8_t)(v >> 16);
+    b->buf[b->len++] = (uint8_t)(v >> 8);
+    b->buf[b->len++] = (uint8_t)v;
+}
+
+/* Append a NUL-terminated string, then pad to a 4-byte boundary. */
+static void b_str_pad(Blob *b, const char *s)
+{
+    size_t n = strlen(s) + 1;
+    memcpy(b->buf + b->len, s, n);
+    b->len += (uint32_t)n;
+    while (b->len & 3u) b->buf[b->len++] = 0;
+}
+
+/* Append a NUL-terminated string with no padding (strings block). */
+static uint32_t b_str(Blob *b, const char *s)
+{
+    uint32_t off = b->len;
+    size_t n = strlen(s) + 1;
+    memcpy(b->buf + b->len, s, n);
+    b->len += (uint32_t)n;
+    return off;
+}
+
+static void put32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)(v >> 24); p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);  p[3] = (uint8_t)v;
+}
+
+/*
+ * Compose a well-formed v17 blob from a struct block and a strings block.
+ * Returns a heap buffer so ASan's redzones sit immediately after the blob and
+ * any over-read is caught precisely.
+ */
+static uint8_t *compose(const Blob *st, const Blob *str, uint32_t *out_size)
+{
+    uint32_t off_rsv    = EOS_DT_HEADER_SIZE;
+    uint32_t off_struct = off_rsv + 8u;            /* one empty reserve entry */
+    uint32_t off_string = off_struct + st->len;
+    uint32_t total      = off_string + str->len;
+
+    uint8_t *b = calloc(1, total);
+    put32(b + 0,  EOS_DT_MAGIC);
+    put32(b + 4,  total);
+    put32(b + 8,  off_struct);
+    put32(b + 12, off_string);
+    put32(b + 16, off_rsv);
+    put32(b + 20, 17);           /* version */
+    put32(b + 24, 16);           /* last_comp_version */
+    put32(b + 28, 0);            /* boot_cpuid_phys */
+    put32(b + 32, str->len);     /* size_dt_strings */
+    put32(b + 36, st->len);      /* size_dt_struct */
+
+    memcpy(b + off_struct, st->buf, st->len);
+    memcpy(b + off_string, str->buf, str->len);
+    *out_size = total;
+    return b;
+}
+
+/*
+ * A small but realistic tree:
+ *
+ *   / {
+ *       model = "EoS Test Board";
+ *       compatible = "eos,test-board";
+ *       uart@40011000 {
+ *           reg = <0x40011000 0x400>;
+ *           interrupts = <37 38>;
+ *           phandle = <1>;
+ *       };
+ *   };
+ */
+static uint8_t *build_valid_dtb(uint32_t *out_size)
+{
+    static Blob st, str;
+    b_reset(&st); b_reset(&str);
+
+    uint32_t s_model   = b_str(&str, "model");
+    uint32_t s_compat  = b_str(&str, "compatible");
+    uint32_t s_reg     = b_str(&str, "reg");
+    uint32_t s_irq     = b_str(&str, "interrupts");
+    uint32_t s_phandle = b_str(&str, "phandle");
+
+    b_u32(&st, EOS_DT_BEGIN_NODE);
+    b_str_pad(&st, "");                       /* root has an empty name */
+
+    b_u32(&st, EOS_DT_PROP);
+    b_u32(&st, 15); b_u32(&st, s_model);
+    b_str_pad(&st, "EoS Test Board");
+
+    b_u32(&st, EOS_DT_PROP);
+    b_u32(&st, 15); b_u32(&st, s_compat);
+    b_str_pad(&st, "eos,test-board");
+
+    b_u32(&st, EOS_DT_BEGIN_NODE);
+    b_str_pad(&st, "uart@40011000");
+
+    b_u32(&st, EOS_DT_PROP);
+    b_u32(&st, 8); b_u32(&st, s_reg);
+    b_u32(&st, 0x40011000); b_u32(&st, 0x400);
+
+    b_u32(&st, EOS_DT_PROP);
+    b_u32(&st, 8); b_u32(&st, s_irq);
+    b_u32(&st, 37); b_u32(&st, 38);
+
+    b_u32(&st, EOS_DT_PROP);
+    b_u32(&st, 4); b_u32(&st, s_phandle);
+    b_u32(&st, 1);
+
+    b_u32(&st, EOS_DT_END_NODE);              /* uart */
+    b_u32(&st, EOS_DT_END_NODE);              /* root */
+    b_u32(&st, EOS_DT_END);
+
+    return compose(&st, &str, out_size);
+}
+
+/* ------------------------------------------------------------------
+ * Happy path
+ * ------------------------------------------------------------------ */
+
+static void test_parse_valid_blob(void)
+{
+    printf("test_parse_valid_blob:\n");
+    uint32_t size = 0;
+    uint8_t *dtb = build_valid_dtb(&size);
+    EosDeviceTree *dt = malloc(sizeof(*dt));
+
+    ASSERT(eos_dt_parse(dt, dtb, size) == 0, "well-formed blob parses");
+    ASSERT(eos_dt_node_count(dt) == 2, "root plus one child node");
+    ASSERT(dt->version == 17, "version read from header");
+    ASSERT(strcmp(dt->model, "EoS Test Board") == 0, "model cached at root");
+    ASSERT(strcmp(dt->compatible, "eos,test-board") == 0,
+           "compatible cached at root");
+
+    free(dt); free(dtb);
+}
+
+static void test_lookup_and_property_access(void)
+{
+    printf("test_lookup_and_property_access:\n");
+    uint32_t size = 0;
+    uint8_t *dtb = build_valid_dtb(&size);
+    EosDeviceTree *dt = malloc(sizeof(*dt));
+    eos_dt_parse(dt, dtb, size);
+
+    ASSERT(eos_dt_find(dt, "/") == dt->root, "root resolves");
+
+    EosDtNode *uart = eos_dt_find(dt, "/uart@40011000");
+    ASSERT(uart != NULL, "child node resolves by path");
+    ASSERT(eos_dt_find(dt, "/nonexistent") == NULL, "unknown path returns NULL");
+
+    if (uart) {
+        ASSERT(uart->parent == dt->root, "child links back to its parent");
+        ASSERT(eos_dt_get_prop(uart, "reg") != NULL, "reg property present");
+        ASSERT(eos_dt_get_prop(uart, "absent") == NULL, "absent property is NULL");
+
+        uint32_t addr = 0, sz = 0;
+        ASSERT(eos_dt_get_reg(uart, &addr, &sz) == 0, "reg decodes");
+        ASSERT(addr == 0x40011000u && sz == 0x400u, "reg holds address and size");
+
+        ASSERT(eos_dt_get_irq(uart, 0) == 37, "first interrupt decodes");
+        ASSERT(eos_dt_get_irq(uart, 1) == 38, "second interrupt decodes");
+        ASSERT(eos_dt_get_irq(uart, 2) == -1, "index past the array is rejected");
+        ASSERT(eos_dt_get_irq(uart, -1) == -1, "negative index is rejected");
+        ASSERT(eos_dt_get_irq(uart, 0x40000000) == -1,
+               "index that would overflow the offset is rejected");
+
+        uint32_t ph = 0;
+        ASSERT(eos_dt_get_u32(uart, "phandle", &ph) == 0 && ph == 1u,
+               "u32 property decodes");
+        ASSERT(eos_dt_find_by_phandle(dt, 1) == uart, "phandle lookup works");
+    }
+
+    ASSERT(eos_dt_find_compatible(dt, "eos,test-board") == dt->root,
+           "compatible lookup finds the root");
+    ASSERT(eos_dt_find_compatible(dt, "vendor,absent") == NULL,
+           "unknown compatible returns NULL");
+
+    char buf[32];
+    ASSERT(eos_dt_get_string(dt->root, "model", buf, (int)sizeof(buf)) == 0 &&
+           strcmp(buf, "EoS Test Board") == 0, "string property copies out");
+
+    free(dt); free(dtb);
+}
+
+/* ------------------------------------------------------------------
+ * Malformed input — each of these was an out-of-bounds read
+ * ------------------------------------------------------------------ */
+
+/* Build a bare 40-byte header with caller-chosen offsets. */
+static uint8_t *lone_header(uint32_t total, uint32_t off_struct,
+                            uint32_t off_string)
+{
+    uint8_t *b = calloc(1, EOS_DT_HEADER_SIZE);
+    put32(b + 0,  EOS_DT_MAGIC);
+    put32(b + 4,  total);
+    put32(b + 8,  off_struct);
+    put32(b + 12, off_string);
+    put32(b + 20, 17);
+    return b;
+}
+
+static void test_rejects_malformed_blobs(void)
+{
+    printf("test_rejects_malformed_blobs:\n");
+    EosDeviceTree *dt = malloc(sizeof(*dt));
+
+    ASSERT(eos_dt_parse(NULL, NULL, 0) == -1, "NULL arguments rejected");
+
+    {   /* Shorter than a header. */
+        uint8_t tiny[8] = {0};
+        ASSERT(eos_dt_parse(dt, tiny, sizeof(tiny)) == -1,
+               "blob shorter than the header is rejected");
+    }
+
+    {   /* Wrong magic. */
+        uint8_t *b = lone_header(EOS_DT_HEADER_SIZE, EOS_DT_HEADER_SIZE, EOS_DT_HEADER_SIZE);
+        put32(b, 0xDEADBEEF);
+        ASSERT(eos_dt_parse(dt, b, EOS_DT_HEADER_SIZE) == -1, "bad magic is rejected");
+        free(b);
+    }
+
+    {   /* off_struct past the end of the buffer.
+           `size - off_struct` used to wrap, giving the walk a huge bound. */
+        uint8_t *b = lone_header(EOS_DT_HEADER_SIZE, 4096, 4096);
+        ASSERT(eos_dt_parse(dt, b, EOS_DT_HEADER_SIZE) == -1,
+               "struct offset past the buffer is rejected");
+        free(b);
+    }
+
+    {   /* totalsize larger than the buffer we were handed. */
+        uint8_t *b = lone_header(0x10000, EOS_DT_HEADER_SIZE, EOS_DT_HEADER_SIZE);
+        ASSERT(eos_dt_parse(dt, b, EOS_DT_HEADER_SIZE) == -1,
+               "totalsize larger than the buffer is rejected");
+        free(b);
+    }
+
+    {   /* BEGIN_NODE whose name has no terminator before the blob ends.
+           strlen() used to run past the allocation. */
+        uint32_t total = 48;
+        uint8_t *b = calloc(1, total);
+        put32(b + 0, EOS_DT_MAGIC); put32(b + 4, total);
+        put32(b + 8, 40); put32(b + 12, 44); put32(b + 20, 17);
+        put32(b + 40, EOS_DT_BEGIN_NODE);
+        memset(b + 44, 'A', 4);          /* four non-NUL bytes, then the end */
+        ASSERT(eos_dt_parse(dt, b, total) == -1,
+               "unterminated node name is rejected");
+        free(b);
+    }
+
+    {   /* PROP with a name offset far outside the strings block. */
+        uint32_t total = 64;
+        uint8_t *b = calloc(1, total);
+        put32(b + 0, EOS_DT_MAGIC); put32(b + 4, total);
+        put32(b + 8, 40); put32(b + 12, 44); put32(b + 20, 17);
+        put32(b + 40, EOS_DT_BEGIN_NODE);       /* root, empty name + padding */
+        put32(b + 48, EOS_DT_PROP);
+        put32(b + 52, 4);
+        put32(b + 56, 0x40000000);              /* nameoff far out of range */
+        put32(b + 60, 0xDEADBEEF);
+        ASSERT(eos_dt_parse(dt, b, total) == -1,
+               "property name offset outside the strings block is rejected");
+        free(b);
+    }
+
+    {   /* Nesting deeper than the parser's node stack.
+           stack[depth - 1] used to read past the end of the local array. */
+        uint32_t depth = EOS_DT_MAX_DEPTH + 8u;
+        uint32_t total = EOS_DT_HEADER_SIZE + depth * 8u + 8u;
+        uint8_t *b = calloc(1, total);
+        put32(b + 0, EOS_DT_MAGIC); put32(b + 4, total);
+        put32(b + 8, EOS_DT_HEADER_SIZE); put32(b + 12, total - 4);
+        put32(b + 20, 17);
+        uint32_t p = EOS_DT_HEADER_SIZE;
+        for (uint32_t i = 0; i < depth; i++) {
+            put32(b + p, EOS_DT_BEGIN_NODE); p += 4;
+            put32(b + p, 0);                 p += 4;   /* empty name + padding */
+        }
+        put32(b + p, EOS_DT_END);
+        ASSERT(eos_dt_parse(dt, b, total) == -1,
+               "nesting deeper than the node stack is rejected");
+        free(b);
+    }
+
+    {   /* END_NODE with nothing open. */
+        uint32_t total = 48;
+        uint8_t *b = calloc(1, total);
+        put32(b + 0, EOS_DT_MAGIC); put32(b + 4, total);
+        put32(b + 8, 40); put32(b + 12, 44); put32(b + 20, 17);
+        put32(b + 40, EOS_DT_END_NODE);
+        put32(b + 44, EOS_DT_END);
+        ASSERT(eos_dt_parse(dt, b, total) == -1, "unbalanced END_NODE is rejected");
+        free(b);
+    }
+
+    {   /* Property length running past the end of the struct block. */
+        uint32_t total = 64;
+        uint8_t *b = calloc(1, total);
+        put32(b + 0, EOS_DT_MAGIC); put32(b + 4, total);
+        put32(b + 8, 40); put32(b + 12, 60); put32(b + 20, 17);
+        put32(b + 40, EOS_DT_BEGIN_NODE);
+        put32(b + 48, EOS_DT_PROP);
+        put32(b + 52, 0xFFFF0000);              /* absurd value length */
+        put32(b + 56, 0);
+        ASSERT(eos_dt_parse(dt, b, total) == -1,
+               "property length past the struct block is rejected");
+        free(b);
+    }
+
+    {   /* Truncated: no FDT_END terminator. */
+        uint32_t total = 48;
+        uint8_t *b = calloc(1, total);
+        put32(b + 0, EOS_DT_MAGIC); put32(b + 4, total);
+        put32(b + 8, 40); put32(b + 12, 44); put32(b + 20, 17);
+        put32(b + 40, EOS_DT_BEGIN_NODE);
+        ASSERT(eos_dt_parse(dt, b, total) == -1, "missing FDT_END is rejected");
+        free(b);
+    }
+
+    free(dt);
+}
+
+/*
+ * Every prefix of a valid blob is malformed. The parser has to reject each one
+ * without reading past the (shortened) buffer — this is the cheap deterministic
+ * stand-in for the fuzz target, and it runs everywhere.
+ */
+static void test_truncations_never_overrun(void)
+{
+    printf("test_truncations_never_overrun:\n");
+    uint32_t size = 0;
+    uint8_t *full = build_valid_dtb(&size);
+    EosDeviceTree *dt = malloc(sizeof(*dt));
+
+    int rejected_all = 1;
+    for (uint32_t n = 0; n < size; n++) {
+        uint8_t *cut = malloc(n ? n : 1);
+        memcpy(cut, full, n);
+        /* Patch totalsize down so the blob is self-consistent about its size. */
+        if (n >= EOS_DT_HEADER_SIZE) put32(cut + 4, n);
+        if (eos_dt_parse(dt, cut, n) == 0) rejected_all = 0;
+        free(cut);
+    }
+    ASSERT(rejected_all, "every truncation of a valid blob is rejected");
+
+    /* And the untruncated blob still parses, so the loop above proves something. */
+    ASSERT(eos_dt_parse(dt, full, size) == 0, "the untruncated blob still parses");
+
+    free(dt); free(full);
+}
+
+/*
+ * Flip one byte at a time across the whole blob. The result may parse or may be
+ * rejected — what matters is that it never reads outside the buffer. Under ASan
+ * this is where the original parser fell over.
+ */
+static void test_single_byte_corruption_is_safe(void)
+{
+    printf("test_single_byte_corruption_is_safe:\n");
+    uint32_t size = 0;
+    uint8_t *full = build_valid_dtb(&size);
+    EosDeviceTree *dt = malloc(sizeof(*dt));
+
+    for (uint32_t i = 0; i < size; i++) {
+        static const uint8_t patterns[] = { 0x00, 0x01, 0x7F, 0x80, 0xFF };
+        for (size_t k = 0; k < sizeof(patterns); k++) {
+            uint8_t *copy = malloc(size);
+            memcpy(copy, full, size);
+            copy[i] = patterns[k];
+            (void)eos_dt_parse(dt, copy, size);   /* must not read out of bounds */
+            free(copy);
+        }
+    }
+    ASSERT(1, "single-byte corruption never reads outside the blob");
+
+    free(dt); free(full);
+}
+
+int main(void)
+{
+    printf("=== EoS Device Tree Parser Tests ===\n\n");
+
+    test_parse_valid_blob();
+    test_lookup_and_property_access();
+    test_rejects_malformed_blobs();
+    test_truncations_never_overrun();
+    test_single_byte_corruption_is_safe();
+
+    printf("\n%d/%d assertions passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

A flattened device tree is untrusted input. It arrives from a prior boot stage
or a flash region, and every offset and length inside the blob is chosen by
whoever produced it. `eos_dt_parse()` consumed those values without validating
them, so a malformed DTB reads outside the buffer in four distinct ways.

The fuzz harness that should have caught this was dead twice over — see
*Why this was not caught* below.

## The bugs

Reproduced with crafted blobs under `-fsanitize=address,undefined`:

| # | Malformed input | What happened | Site |
|---|---|---|---|
| 1 | `off_struct` > buffer length | loop bound `pos < (size - off_struct)` wraps → walk runs unbounded | `devicetree.c:37` |
| 2 | `BEGIN_NODE` name with no terminator | `strlen()` / `strncpy()` run past the allocation | `devicetree.c:48` |
| 3 | property `nameoff` = `0x40000000` | `strings + nameoff` dereferenced far outside the mapping | `devicetree.c:77` |
| 4 | nesting deeper than 32 | write guarded by `if (depth < 32)`, but `stack[depth - 1]` read unguarded | `devicetree.c:55` |

Case 4 is the one worth calling out — the array write *was* bounds-checked, so
it reads as safe on a skim. `depth` kept incrementing past the guard, and the
next `BEGIN_NODE` read `stack[32]` off the end of a stack array:

```
runtime error: index 32 out of bounds for type 'EosDtNode *[32]'
ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 8
    #0 eos_dt_parse devicetree.c:55
```

Two accessors had the same class of problem:

* `eos_dt_find_compatible()` called `strstr()` on `prop->data`. A property value
  is raw bytes; one that filled the 256-byte buffer has no terminator, so the
  search runs into whatever follows.
* `eos_dt_get_irq()` computed `index * 4` and used it as an offset *before*
  range-checking, so a negative index became a huge unsigned offset.

## Approach

Validate before dereferencing, everywhere:

* **Header offsets** — `totalsize` may not exceed the buffer actually passed in,
  and both blocks must begin inside the blob. The declared `size_dt_struct` /
  `size_dt_strings` are honoured only when they fit, otherwise clamped to the
  rest of the blob. Either way the walk stays in bounds.
* **Three small primitives** carry the checks so no call site can forget them:
  `dt_read_be32()` (4 bytes inside the block), `dt_strlen_at()` (terminator
  found before the block ends), `dt_align4()` (refuses the wrapping cases).
* **Depth** — nesting beyond `EOS_DT_MAX_DEPTH` is rejected rather than clamped.
  Silently dropping nodes would produce a tree that does not describe the blob.
* **Termination** — `pos` advances by ≥4 every iteration and every read is
  bounds-checked, so the loop terminates on any input. A blob with no `FDT_END`
  is rejected rather than walked to the end.
* **Property values are bytes, not strings.** `dt_prop_contains()` searches
  within `prop->len`. I kept substring semantics rather than switching to proper
  `compatible` string-list matching — that is a behaviour change, and this PR is
  about memory safety. Noted under *Limitations*.

`EOS_DT_MAX_DEPTH`, `EOS_DT_MAX_CHILDREN` and `EOS_DT_HEADER_SIZE` are now named
constants in the header instead of the literals `32`, `16` and `40`.

**The public API is unchanged.** Well-formed blobs parse exactly as before; the
only behavioural difference is that malformed ones now return `-1`.

## Why this was not caught

`tests/fuzz/fuzz_devicetree.c` exists and targets this exact parser, but:

1. **`tests/fuzz/` was never added by any `add_subdirectory`.** No fuzz target
   in the repo could be built — not `fuzz_devicetree`, not `fuzz_sha256`, not
   `fuzz_aes`, despite the CMakeLists advertising them.
2. `fuzz_devicetree` was *additionally* commented out, with the note "these
   require the parser libraries to be linked" — the `eos_devicetree` target it
   names does exist and links fine.
3. The harness declared `extern int eos_dtb_parse(const void *, size_t)`, which
   does not exist anywhere in the tree. The real entry point is
   `eos_dt_parse(EosDeviceTree *, const uint8_t *, uint32_t)`.

All three are fixed. `add_subdirectory(fuzz)` is wired in, the target is
uncommented, and the harness calls the real API.

## Testing

**New: `tests/test_devicetree.c`** — 37 assertions, wired into ctest.

* Happy path against a hand-built valid v17 blob: parse, node count, cached
  `model`/`compatible`, path lookup, parent links, and the `reg` / `u32` /
  `string` / `irq` / `phandle` accessors.
* One case per bug above, plus bad magic, short blob, `totalsize` larger than
  the buffer, unbalanced `END_NODE`, property length past the struct block, and
  a missing `FDT_END`.
* **Truncation sweep** — every prefix of a valid blob must be rejected, with the
  untruncated blob still parsing so the loop proves something.
* **Corruption sweep** — every byte replaced with each of 5 patterns
  (~2,000 malformed inputs); each must parse or be rejected, never over-read.

```console
$ cmake -S . -B build -DEOS_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
$ cmake --build build -j                    # no new warnings under -Wall -Wextra
$ ctest --test-dir build --output-on-failure
100% tests passed out of 22                 # was 21
$ ./build/tests/test_devicetree
37/37 assertions passed
```

**Sanitizers — the same suite against the pre-fix parser:**

```console
$ clang -fsanitize=address,undefined -fno-sanitize-recover=all \
    tests/test_devicetree.c <parser> -o t

  with this change:  37/37 assertions passed          exit 0
  pre-fix parser:    ERROR: AddressSanitizer: heap-buffer-overflow
                     SUMMARY: ... in eos_dt_parse    exit 134 (SIGABRT)
```

**Mutation fuzzing** (libFuzzer is unavailable on this host — AppleClang ships
no `libclang_rt.fuzzer`, so I wrote a standalone ASan+UBSan mutation driver as a
stand-in). It mutates a valid blob, generates random bodies with correct magic,
and generates fully random buffers, then exercises the accessors on whatever
tree comes out:

```console
  pre-fix parser:   ERROR: AddressSanitizer: BUS ... in eos_dt_parse   (immediate)
  with this change: 5 seeds x 200-300k iterations = 1.1M inputs
                    ~9,400 accepted per run, zero sanitizer reports
```

`fuzz_devicetree` itself is **NOT RUN** here for the reason above; it is
verified to compile against the real API and the CMake wiring is verified to
configure (`-- Fuzz targets: fuzz_sha256, fuzz_aes, fuzz_devicetree`).

## Limitations and considerations

* **Stricter than before, deliberately.** Blobs with an unbalanced `END_NODE`,
  no `FDT_END`, or nesting past 32 are now rejected rather than partially
  parsed. All are malformed per the FDT spec; a partially-built tree is worse
  than a clear failure. If any board ships such a blob this would surface as a
  parse failure rather than silent corruption.
* **`eos_dt_find_compatible()` still does a substring match**, not proper
  `compatible` string-list matching. `strstr("arm,cortex")` matching inside
  `"arm,cortex-a53"` is arguably wrong, but changing it is a behaviour change
  beyond this fix. Worth a follow-up.
* **Node/property/child limits still silently truncate.** A node with more than
  16 properties keeps the first 16, as before. I did not change this — it is a
  capacity policy, not a safety issue, and changing it would alter behaviour for
  valid blobs.
* `eos_dt_parse()` has no callers in-tree today; it is public API. The fix
  matters for whoever wires it into the boot path.
* Sanitizers are not part of the default CMake options here, so CI runs the new
  suite unsanitized. It still catches all four bugs (the pre-fix parser aborts),
  but adding an `EOS_SANITIZE` option would be a reasonable follow-up.

## Type of Change

- [x] fix — Bug fix
- [x] test — Add or fix tests
- [x] build — Build system changes
- [x] docs — Documentation

## Changes

- `drivers/devicetree/devicetree.c` — bounds-checked parse; hardened
  `eos_dt_find_compatible()` and `eos_dt_get_irq()`.
- `drivers/devicetree/devicetree.h` — `EOS_DT_MAX_DEPTH`,
  `EOS_DT_MAX_CHILDREN`, `EOS_DT_HEADER_SIZE`.
- `tests/test_devicetree.c` — new suite (37 assertions).
- `tests/CMakeLists.txt` — register `test_devicetree`; `add_subdirectory(fuzz)`.
- `tests/fuzz/CMakeLists.txt` — enable `fuzz_devicetree`.
- `tests/fuzz/fuzz_devicetree.c` — call the real API.
- `docs/security-hardening-guide.md` — section 13, *Parsing Untrusted Binary Input*.
- `CHANGELOG.md` — `Unreleased` entries.

## Pre-Submission Checklist

- [x] Compiles without warnings (`-Wall -Wextra`)
- [x] All existing tests pass (22/22, was 21)
- [x] New tests added, verified to abort on the pre-fix parser
- [x] Documentation updated
- [x] Public API unchanged
