### PR TITLE
Validate network socket protocol

### DIFF
--- a/net/src/net.c
+++ b/net/src/net.c
@@ -27,8 +27,14 @@ void eos_net_deinit(void)
 
 eos_socket_t eos_net_socket(eos_net_proto_t proto)
 {
-    (void)proto;
-    if (!net_initialized) return EOS_SOCKET_INVALID;
+    if (!net_initialized) {
+        return EOS_SOCKET_INVALID;
+    }
+
+    if (proto != EOS_NET_TCP && proto != EOS_NET_UDP) {
+        return EOS_SOCKET_INVALID;
+    }
+
     static int next_fd = 1;
     return (eos_socket_t)next_fd++;
 }

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -30,6 +30,16 @@ static void test_net_socket_udp(void) {
     eos_net_deinit();
     PASS("net socket UDP");
 }
+static void test_net_socket_invalid_protocol(void) {
+    eos_net_init();
+
+    eos_socket_t s = eos_net_socket((eos_net_proto_t)99);
+
+    assert(s == EOS_SOCKET_INVALID);
+
+    eos_net_deinit();
+    PASS("net socket invalid protocol");
+}
 static void test_net_bind(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
@@ -143,6 +153,7 @@ int main(void) {
     test_net_init();
     test_net_socket_tcp();
     test_net_socket_udp();
+    test_net_socket_invalid_protocol();
     test_net_bind();
     test_net_listen();
     test_net_close();


### PR DESCRIPTION
## Summary

Validate the protocol passed to `eos_net_socket()`.

## Changes

- Return `EOS_SOCKET_INVALID` for unsupported protocols.
- Added a regression test for an invalid protocol value.

## Testing

- All 16 network tests passed.
- `git diff --check` passes cleanly.