### PR TITLE
fix(power): reject invalid power modes

### DIFF
--- a/power/src/power.c
+++ b/power/src/power.c
@@ -41,7 +41,7 @@ void eos_power_deinit(void)
 
 int eos_power_enter_mode(eos_power_mode_t mode)
 {
-    if (!power_initialized) return -1;
+    if (!power_initialized || mode < EOS_POWER_RUN || mode > EOS_POWER_SHUTDOWN) return -1;
     current_mode = mode;
     return 0;
 }

--- a/tests/test_power.c
+++ b/tests/test_power.c
@@ -42,6 +42,14 @@ static void test_power_enter_deep_sleep(void) {
     eos_power_deinit();
     PASS("power enter deep sleep");
 }
+static void test_power_enter_invalid_mode(void) {
+    eos_power_config_t cfg = { .adc_channel = 0, .vbat_full_mv = 4200, .vbat_empty_mv = 3000, .divider_ratio_x10 = 20 };
+    eos_power_init(&cfg);
+    assert(eos_power_enter_mode((eos_power_mode_t)(EOS_POWER_SHUTDOWN + 1)) != 0);
+    assert(eos_power_get_mode() == EOS_POWER_RUN);
+    eos_power_deinit();
+    PASS("power enter invalid mode");
+}
 static void test_power_wake_sources(void) {
     eos_power_config_t cfg = { .adc_channel = 0, .vbat_full_mv = 4200, .vbat_empty_mv = 3000, .divider_ratio_x10 = 20 };
     eos_power_init(&cfg);
@@ -121,6 +129,7 @@ int main(void) {
     test_power_mode_default();
     test_power_enter_sleep();
     test_power_enter_deep_sleep();
+    test_power_enter_invalid_mode();
     test_power_wake_sources();
     test_power_battery_mv();
     test_power_battery_pct();


### PR DESCRIPTION
## Summary

This PR adds validation to `eos_power_enter_mode()` so invalid power-mode values are rejected before updating the power manager state.

## Problem

Previously, `eos_power_enter_mode()` accepted values outside the valid `eos_power_mode_t` range.

For example, a value greater than `EOS_POWER_SHUTDOWN` returned success and was stored as the current power mode.

This could leave the power manager in an unsupported state and potentially cause incorrect behavior during platform-specific power transitions.

## Solution

Validate the requested mode before updating `current_mode`.

Invalid values now:
- return `-1`
- leave the existing power mode unchanged

All valid power modes continue to behave exactly as before.

## Testing

- Regression test confirmed the bug before the fix.
- Targeted `test_power`: 1/1 passed after the fix.
- Full native CTest suite: 21/21 passed.
- Python test suite: 10/10 passed.
- `EOS_PRODUCT=iot` build passed.
- AppleClang `-Wall -Wextra`: no warnings.
- `git diff --check`: passed.
- Independent review completed with no findings.

## Impact

This is a focused input-validation fix.

No public API changes, new dependencies, or platform-specific behavior were introduced.