### PR TITLE
fix(power): reject negative peripheral IDs

### DIFF
--- a/power/src/power.c
+++ b/power/src/power.c
@@ -95,21 +95,21 @@ int eos_power_get_battery_info(eos_battery_info_t *info)
 
 int eos_power_enable_peripheral(eos_peripheral_id_t periph)
 {
-    if (periph >= EOS_PERIPH_MAX) return -1;
+    if ((uintmax_t)periph >= (uintmax_t)EOS_PERIPH_MAX) return -1;
     periph_enabled[periph] = true;
     return 0;
 }
 
 int eos_power_disable_peripheral(eos_peripheral_id_t periph)
 {
-    if (periph >= EOS_PERIPH_MAX) return -1;
+    if ((uintmax_t)periph >= (uintmax_t)EOS_PERIPH_MAX) return -1;
     periph_enabled[periph] = false;
     return 0;
 }
 
 bool eos_power_is_peripheral_enabled(eos_peripheral_id_t periph)
 {
-    if (periph >= EOS_PERIPH_MAX) return false;
+    if ((uintmax_t)periph >= (uintmax_t)EOS_PERIPH_MAX) return false;
     return periph_enabled[periph];
 }
 

--- a/tests/test_power.c
+++ b/tests/test_power.c
@@ -103,6 +103,13 @@ static void test_power_periph_invalid(void) {
     eos_power_config_t cfg = { .adc_channel = 0, .vbat_full_mv = 4200, .vbat_empty_mv = 3000, .divider_ratio_x10 = 20 };
     eos_power_init(&cfg);
     assert(eos_power_enable_peripheral(EOS_PERIPH_MAX) != 0);
+    assert(eos_power_disable_peripheral(EOS_PERIPH_MAX) != 0);
+    assert(eos_power_is_peripheral_enabled(EOS_PERIPH_MAX) == false);
+
+    eos_peripheral_id_t negative_id = (eos_peripheral_id_t)-1;
+    assert(eos_power_enable_peripheral(negative_id) != 0);
+    assert(eos_power_disable_peripheral(negative_id) != 0);
+    assert(eos_power_is_peripheral_enabled(negative_id) == false);
     eos_power_deinit();
     PASS("power periph invalid id");
 }


### PR DESCRIPTION
## Problem

The peripheral power APIs only rejected IDs greater than or equal to `EOS_PERIPH_MAX`. On implementations where `eos_peripheral_id_t` is signed, a negative value could pass validation and index before the `periph_enabled` array, causing undefined behavior.

## Implementation

- Validate IDs after conversion to `uintmax_t`, which rejects negative values across signed and unsigned enum representations without narrowing.
- Apply the same guard to enable, disable, and query operations.
- Extend the power regression test to cover `EOS_PERIPH_MAX` and `-1` for all three APIs.

## Validation

- Built with GCC in strict C11 mode using `-Wall -Wextra -Werror`.
- Ran `test_power`: all 14 tests passed.
- Ran `git diff --check`: passed.

## Additional considerations

This does not change the public API or valid peripheral behavior. Full CMake/CTest and product-profile builds were not run locally because CMake is unavailable in the environment; repository CI should provide the full matrix. ASan and UBSan were also unavailable because the host sanitizer runtime libraries are not installed.