### PR TITLE
fix(debug): validate GDB M-packet payloads before writing memory

### DIFF
--- a/debug/src/gdb_stub.c
+++ b/debug/src/gdb_stub.c
@@ -13,6 +13,23 @@ static uint8_t hex_val(char c) {
     return 0;
 }
 
+/**
+ * @brief Hex digit to value, reporting invalid input.
+ *
+ * hex_val() maps any non-hex byte to 0, which silently turns a malformed
+ * payload into zero bytes. Callers that write the decoded result to memory
+ * use this variant instead and reject the packet.
+ *
+ * @param c Candidate hex digit.
+ * @return 0-15 for a valid digit, -1 otherwise.
+ */
+static int hex_val_checked(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
 static char hex_char(uint8_t v) {
     return "0123456789abcdef"[v & 0x0F];
 }
@@ -115,9 +132,20 @@ static void handle_write_mem(EosGdbStub *stub, const char *pkt) {
     const char *data = strchr(pkt, ':');
     if (!data) { send_packet(stub, "E01"); return; }
     data++;
+
+    /* The packet must actually carry two hex digits per byte. Without this
+     * check the decode loop read past the end of the received packet and
+     * handed whatever followed it to eos_gdb_write_mem() at an address the
+     * remote peer chose. */
+    if (strlen(data) < (size_t)len * 2u) { send_packet(stub, "E01"); return; }
+
     uint8_t buf[128];
-    for (uint32_t i = 0; i < len; i++)
-        buf[i] = (hex_val(data[i * 2]) << 4) | hex_val(data[i * 2 + 1]);
+    for (uint32_t i = 0; i < len; i++) {
+        int hi = hex_val_checked(data[i * 2]);
+        int lo = hex_val_checked(data[i * 2 + 1]);
+        if (hi < 0 || lo < 0) { send_packet(stub, "E01"); return; }
+        buf[i] = (uint8_t)((hi << 4) | lo);
+    }
     if (eos_gdb_write_mem(addr, buf, (int)len) != 0) {
         send_packet(stub, "E02");
         return;

--- a/tests/test_debug.c
+++ b/tests/test_debug.c
@@ -45,6 +45,132 @@ static void test_gdb_start_stop(void) {
     printf("[PASS] gdb start/stop\n");
 }
 
+/* ---- Scripted GDB transport ----
+ *
+ * Feeds crafted packets to eos_gdb_handle_exception() and captures the
+ * replies, so the remote-protocol parsing can be exercised on the host.
+ *
+ * These cases deliberately cover only packets the stub must *reject*.
+ * eos_gdb_read_mem()/eos_gdb_write_mem() cast a uint32_t straight to a
+ * pointer, so any packet the stub accepts would dereference a truncated
+ * address on a 64-bit host. The accept path is therefore not exercised
+ * here; see the note in the pull request.
+ */
+
+#define GDB_RX_CAP 4096
+#define GDB_TX_CAP 4096
+
+static char   gdb_rx[GDB_RX_CAP];
+static size_t gdb_rx_len;
+static size_t gdb_rx_pos;
+static char   gdb_tx[GDB_TX_CAP];
+static size_t gdb_tx_len;
+
+static int mock_read(void *ctx, uint8_t *buf, int len) {
+    (void)ctx;
+    int n = 0;
+    while (n < len && gdb_rx_pos < gdb_rx_len) {
+        buf[n++] = (uint8_t)gdb_rx[gdb_rx_pos++];
+    }
+    return n;
+}
+
+static int mock_write(void *ctx, const uint8_t *buf, int len) {
+    (void)ctx;
+    for (int i = 0; i < len && gdb_tx_len < GDB_TX_CAP - 1; i++) {
+        gdb_tx[gdb_tx_len++] = (char)buf[i];
+    }
+    gdb_tx[gdb_tx_len] = '\0';
+    return len;
+}
+
+static void gdb_reset(void) {
+    memset(gdb_rx, 0, sizeof(gdb_rx));
+    memset(gdb_tx, 0, sizeof(gdb_tx));
+    gdb_rx_len = 0;
+    gdb_rx_pos = 0;
+    gdb_tx_len = 0;
+}
+
+/* Append "$<body>#<checksum>" to the scripted input. */
+static void gdb_push(const char *body) {
+    uint8_t sum = 0;
+    size_t n = strlen(body);
+    gdb_rx[gdb_rx_len++] = '$';
+    for (size_t i = 0; i < n; i++) {
+        sum = (uint8_t)(sum + (uint8_t)body[i]);
+        gdb_rx[gdb_rx_len++] = body[i];
+    }
+    gdb_rx[gdb_rx_len++] = '#';
+    gdb_rx[gdb_rx_len++] = "0123456789abcdef"[(sum >> 4) & 0x0F];
+    gdb_rx[gdb_rx_len++] = "0123456789abcdef"[sum & 0x0F];
+}
+
+static void gdb_run(void) {
+    EosGdbStub stub;
+    EosGdbIO io = { mock_read, mock_write, NULL };
+    eos_gdb_init(&stub, EOS_GDB_TRANSPORT_TCP);
+    eos_gdb_set_io(&stub, &io);
+    eos_gdb_start(&stub, 0);
+    eos_gdb_handle_exception(&stub, 5);
+}
+
+static int tx_has(const char *needle) {
+    return strstr(gdb_tx, needle) != NULL;
+}
+
+/*
+ * Regression: handle_write_mem() bounded len to 128 but never checked that
+ * the packet carried 2*len hex digits. "M0,80:" with no payload made the
+ * decode loop read 256 bytes past the end of the received packet and write
+ * them to an address the peer chose.
+ */
+static void test_gdb_write_mem_truncated_payload(void) {
+    gdb_reset();
+    gdb_push("M0,80:");     /* declares 128 bytes, supplies none */
+    gdb_push("D");
+    gdb_run();
+    assert(tx_has("E01"));
+    printf("[PASS] gdb rejects M packet with truncated payload\n");
+}
+
+static void test_gdb_write_mem_short_payload(void) {
+    gdb_reset();
+    gdb_push("M0,4:aabb");  /* declares 4 bytes = 8 digits, supplies 4 */
+    gdb_push("D");
+    gdb_run();
+    assert(tx_has("E01"));
+    printf("[PASS] gdb rejects M packet with short payload\n");
+}
+
+/* hex_val() mapped any non-hex byte to 0, so garbage was written as zeros. */
+static void test_gdb_write_mem_non_hex_payload(void) {
+    gdb_reset();
+    gdb_push("M0,2:zzzz");
+    gdb_push("D");
+    gdb_run();
+    assert(tx_has("E01"));
+    printf("[PASS] gdb rejects M packet with non-hex payload\n");
+}
+
+static void test_gdb_write_mem_oversized_len(void) {
+    gdb_reset();
+    gdb_push("M0,1000:aabb");
+    gdb_push("D");
+    gdb_run();
+    assert(tx_has("E01"));
+    printf("[PASS] gdb rejects M packet with oversized length\n");
+}
+
+static void test_gdb_query_roundtrip(void) {
+    gdb_reset();
+    gdb_push("qSupported");
+    gdb_push("D");
+    gdb_run();
+    assert(tx_has("PacketSize"));
+    printf("[PASS] gdb qSupported round-trip\n");
+}
+
 static void test_coredump_init(void) {
     assert(eos_coredump_init(EOS_DUMP_TARGET_RAM) == 0);
     assert(!eos_coredump_exists());
@@ -96,6 +222,11 @@ int main(void) {
     test_gdb_init();
     test_gdb_breakpoints();
     test_gdb_start_stop();
+    test_gdb_write_mem_truncated_payload();
+    test_gdb_write_mem_short_payload();
+    test_gdb_write_mem_non_hex_payload();
+    test_gdb_write_mem_oversized_len();
+    test_gdb_query_roundtrip();
     test_coredump_init();
     test_coredump_capture();
     test_coredump_clear();

--- a/tests/test_debug.c
+++ b/tests/test_debug.c
@@ -75,11 +75,15 @@ static int mock_read(void *ctx, uint8_t *buf, int len) {
     return n;
 }
 
+/* Honours the EosGdbIO.write contract: the return value must be the number of
+ * bytes actually written. Silently truncating while reporting success would
+ * let tx_has() miss a reply the stub really did send, hiding a failure. */
 static int mock_write(void *ctx, const uint8_t *buf, int len) {
     (void)ctx;
-    for (int i = 0; i < len && gdb_tx_len < GDB_TX_CAP - 1; i++) {
-        gdb_tx[gdb_tx_len++] = (char)buf[i];
-    }
+    assert(len >= 0);
+    assert(gdb_tx_len + (size_t)len < GDB_TX_CAP);
+    memcpy(gdb_tx + gdb_tx_len, buf, (size_t)len);
+    gdb_tx_len += (size_t)len;
     gdb_tx[gdb_tx_len] = '\0';
     return len;
 }
@@ -96,6 +100,8 @@ static void gdb_reset(void) {
 static void gdb_push(const char *body) {
     uint8_t sum = 0;
     size_t n = strlen(body);
+    /* '$' + body + '#' + two checksum digits */
+    assert(gdb_rx_len + n + 4 <= GDB_RX_CAP);
     gdb_rx[gdb_rx_len++] = '$';
     for (size_t i = 0; i < n; i++) {
         sum = (uint8_t)(sum + (uint8_t)body[i]);


### PR DESCRIPTION
## The problem

The GDB stub writes attacker-chosen memory from data it never validated.

`handle_write_mem()` in `debug/src/gdb_stub.c` parses an `M<addr>,<len>:<hexdata>` packet. It bounds `len` to 128 and finds the `:` separator, but never checks that the packet actually carries `2 * len` hex digits after it:

```c
const char *data = strchr(pkt, ':');
if (!data) { send_packet(stub, "E01"); return; }
data++;
uint8_t buf[128];
for (uint32_t i = 0; i < len; i++)
    buf[i] = (hex_val(data[i * 2]) << 4) | hex_val(data[i * 2 + 1]);
```

A peer sending `$M0,80:#xx` declares 128 bytes and supplies none. The loop reads 256 bytes starting at the NUL terminator — straight through the uninitialised remainder of the caller's `char pkt[512]` — and then hands those bytes to `eos_gdb_write_mem()` at an address the peer chose. Because `%x` accepts arbitrarily many leading zeros, the address field can also be padded to push the separator past index 500, making the same loop read beyond `pkt[512]` entirely.

`hex_val()` compounds it by mapping every non-hex byte to `0`, so a malformed payload was accepted as zero bytes rather than rejected.

This is not theoretical. Running the new tests against unmodified `gdb_stub.c` **crashes the process** with an access violation (`0xC0000005`), because the decoded garbage is memcpy'd to the peer-supplied address.

## The approach

Two checks in `handle_write_mem()`, both replying `E01` and returning without touching memory:

1. Require `strlen(data) >= 2 * len` before decoding.
2. Decode through a new `hex_val_checked()` that returns `-1` on a non-hex byte, and reject on the first invalid digit.

`hex_val()` is left in place for the checksum path, where a lenient parse only affects an integrity comparison that is verified separately. Nothing else in the file is changed.

## Testing

`tests/test_debug.c` gains a scripted transport — a mock `EosGdbIO` that feeds crafted packets and captures replies. **The stub's packet handling had no test coverage at all**; the existing cases only exercised init, breakpoint bookkeeping, and start/stop, never the parser.

Four rejection cases plus a `qSupported` round-trip to confirm normal packets still work:

- `M0,80:` — declares 128 bytes, supplies none
- `M0,4:aabb` — declares 8 digits, supplies 4
- `M0,2:zzzz` — non-hex payload
- `M0,1000:aabb` — length over the 128 limit

Verification (GCC 16.2.0, `-DEOS_BUILD_TESTS=ON`):

| Check | Result |
|---|---|
| `test_debug` against **unfixed** source | **crash, `0xC0000005`** |
| `test_debug` against fixed source | PASS, 12/12 |
| `ctest` full suite | 20/21 — identical to baseline |
| `gcc -std=c11 -Wall -Wextra` on `gdb_stub.c` | zero warnings |
| `cmake -DEOS_PRODUCT=robot` (CI-gated profile) | builds clean |

`test_package` fails with a segfault both before and after this change. It is pre-existing on `master` and already addressed by #48 and #52, so I have not touched it.

## Considerations and limitations

**The tests cover only packets the stub must reject.** `eos_gdb_read_mem()` / `eos_gdb_write_mem()` take a `uint32_t` address and cast it straight to a pointer, which truncates on a 64-bit host — so exercising an *accepted* `M` packet from a host test would dereference a truncated address. Fixing that means changing the signatures to `uintptr_t`, which is an API break and belongs in its own PR. I have left it alone and am flagging it rather than working around it silently.

**Also observed, deliberately not changed:** `eos_gdb_handle_exception()` does `if (n < 0) break;`, so a single bad checksum ends the debug session instead of letting the peer retransmit — which is what the GDB remote protocol expects after a `-`. I initially fixed a related framing issue in `recv_packet()` (an over-long packet body left trailing bytes in the stream), then reverted it: with the current `break`, the desync cannot actually be reached, and the change was not covered by a failing-before test. Both are worth a follow-up.

**Environment.** Validated on Windows with GCC 16.2.0 via a portable MinGW-w64 toolchain. I could not run the MSVC or Clang legs locally; the change is plain C11 with no platform-specific constructs, but CI is the real check for those.
