### PR TITLE
fix(eos): make tick deadlines survive the 32-bit tick wraparound

### DIFF
--- a/kernel/include/eos/kernel.h
+++ b/kernel/include/eos/kernel.h
@@ -86,6 +86,7 @@ typedef struct {
     uint32_t *stack_base;
     uint32_t *stack_ptr;
     uint32_t wake_tick;
+    uint8_t  wake_armed;   /* 1 when wake_tick holds a real deadline */
     uint32_t run_count;
 } eos_task_t;
 

--- a/kernel/include/eos/kernel_internal.h
+++ b/kernel/include/eos/kernel_internal.h
@@ -24,6 +24,19 @@ extern volatile uint32_t g_tick;
 extern eos_task_t g_tasks[EOS_MAX_TASKS];
 
 /**
+ * @brief True once @p now has reached or passed @p deadline.
+ *
+ * Compares the signed difference rather than the two values directly, so
+ * the result stays correct when the tick counter wraps past UINT32_MAX.
+ * An absolute `now >= deadline` test fires immediately as soon as the
+ * deadline wraps, waking the task roughly 2^32 ticks early.
+ *
+ * Valid while the deadline is less than 2^31 ticks ahead — about 24.9 days
+ * at 1 ms per tick.
+ */
+#define EOS_TICK_REACHED(now, deadline) ((int32_t)((uint32_t)(now) - (uint32_t)(deadline)) >= 0)
+
+/**
  * @brief Get a task's current priority.
  */
 uint8_t eos_task_get_priority_internal(eos_task_handle_t h);
@@ -36,13 +49,14 @@ void eos_task_set_priority_internal(eos_task_handle_t h, uint8_t prio);
 /**
  * @brief Block a task with a timeout.
  *
- * Sets the task state to BLOCKED and wake_tick to g_tick + timeout_ms.
- * If timeout_ms is EOS_WAIT_FOREVER, wake_tick is set to 0 (never auto-wake).
+ * Sets the task state to BLOCKED and wake_tick to g_tick + timeout_ms,
+ * marking the deadline live via wake_armed. If timeout_ms is
+ * EOS_WAIT_FOREVER, wake_armed stays 0 and the task never auto-wakes.
  */
 void eos_task_block_with_timeout(eos_task_handle_t h, uint32_t timeout_ms);
 
 /**
- * @brief Unblock a task (set state to READY, clear wake_tick).
+ * @brief Unblock a task (set state to READY, disarm the wake deadline).
  */
 void eos_task_unblock(eos_task_handle_t h);
 

--- a/kernel/src/task.c
+++ b/kernel/src/task.c
@@ -152,9 +152,10 @@ void eos_task_wake_check(uint32_t current_tick)
 {
     for (int i = 0; i < EOS_MAX_TASKS; i++) {
         eos_task_t *t = &g_tasks[i];
-        if (t->state == EOS_TASK_BLOCKED && t->wake_tick > 0 &&
-            current_tick >= t->wake_tick) {
+        if (t->state == EOS_TASK_BLOCKED && t->wake_armed &&
+            EOS_TICK_REACHED(current_tick, t->wake_tick)) {
             t->state = EOS_TASK_READY;
+            t->wake_armed = 0;
             t->wake_tick = 0;
         }
     }
@@ -341,6 +342,7 @@ void eos_task_delay_ms(uint32_t ms)
     if (g_current >= 0) {
         uint32_t crit = eos_port_enter_critical();
         g_tasks[g_current].wake_tick = g_tick + ms;
+        g_tasks[g_current].wake_armed = 1;
         g_tasks[g_current].state = EOS_TASK_BLOCKED;
         eos_port_exit_critical(crit);
         eos_port_yield();
@@ -429,7 +431,7 @@ void eos_swtimer_tick(uint32_t current_tick)
     for (int i = 0; i < EOS_MAX_TIMERS; i++) {
         swtimer_t *t = &g_timers[i];
         if (!t->in_use || !t->active) continue;
-        if (current_tick >= t->next_tick) {
+        if (EOS_TICK_REACHED(current_tick, t->next_tick)) {
             t->callback((eos_swtimer_handle_t)i, t->ctx);
             if (t->auto_reload) {
                 t->next_tick = current_tick + t->period_ticks;
@@ -466,9 +468,11 @@ void eos_task_block_with_timeout(eos_task_handle_t h, uint32_t timeout_ms)
     if (h >= EOS_MAX_TASKS) return;
     g_tasks[h].state = EOS_TASK_BLOCKED;
     if (timeout_ms == EOS_WAIT_FOREVER) {
-        g_tasks[h].wake_tick = 0;  /* Never auto-wake */
+        g_tasks[h].wake_tick = 0;
+        g_tasks[h].wake_armed = 0;  /* Never auto-wake */
     } else {
         g_tasks[h].wake_tick = g_tick + timeout_ms;
+        g_tasks[h].wake_armed = 1;
     }
 }
 
@@ -477,4 +481,5 @@ void eos_task_unblock(eos_task_handle_t h)
     if (h >= EOS_MAX_TASKS) return;
     g_tasks[h].state = EOS_TASK_READY;
     g_tasks[h].wake_tick = 0;
+    g_tasks[h].wake_armed = 0;
 }

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -135,6 +135,120 @@ static void test_queue_full(void) {
     printf("[PASS] queue full/peek\n");
 }
 
+/* ------------------------------------------------------------------
+ * Tick wraparound
+ *
+ * g_tick is a free-running uint32_t. Deadlines are computed as
+ * g_tick + timeout, so they wrap. Comparing them with an absolute
+ * `now >= deadline` is wrong across that wrap, and using 0 as the
+ * "wait forever" sentinel collides with a deadline that lands on 0.
+ * ------------------------------------------------------------------ */
+
+extern volatile uint32_t g_tick;
+extern void eos_task_wake_check(uint32_t current_tick);
+extern void eos_swtimer_tick(uint32_t current_tick);
+extern void eos_task_block_with_timeout(eos_task_handle_t h, uint32_t timeout_ms);
+extern void eos_task_unblock(eos_task_handle_t h);
+
+static int g_timer_fired = 0;
+static void wrap_timer_cb(eos_swtimer_handle_t h, void *ctx) {
+    (void)h; (void)ctx; g_timer_fired++;
+}
+
+static void test_wake_tick_wraparound(void) {
+    eos_kernel_init();
+    int h = eos_task_create("wrap", test_entry, NULL, 5, 1024);
+    assert(h >= 0);
+
+    /* 0xFFFFFF00 + 1000 wraps to 0x2E8. */
+    g_tick = 0xFFFFFF00u;
+    eos_task_block_with_timeout((eos_task_handle_t)h, 1000);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_BLOCKED);
+
+    /* One tick later the deadline has not arrived. The absolute compare
+     * saw 0xFFFFFF01 >= 0x2E8 and woke the task ~49.7 days early. */
+    eos_task_wake_check(0xFFFFFF01u);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_BLOCKED);
+
+    /* Still blocked one tick before the deadline... */
+    eos_task_wake_check(0x2E7u);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_BLOCKED);
+
+    /* ...and awake exactly on it. */
+    eos_task_wake_check(0x2E8u);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_READY);
+
+    g_tick = 0;
+    printf("[PASS] wake tick wraparound\n");
+}
+
+static void test_wake_deadline_of_zero(void) {
+    eos_kernel_init();
+    int h = eos_task_create("zero", test_entry, NULL, 5, 1024);
+    assert(h >= 0);
+
+    /* 0xFFFFFF00 + 0x100 == 0 exactly. wake_tick == 0 doubled as the
+     * "wait forever" sentinel, so this bounded wait never expired. */
+    g_tick = 0xFFFFFF00u;
+    eos_task_block_with_timeout((eos_task_handle_t)h, 0x100u);
+
+    eos_task_wake_check(0xFFFFFFFFu);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_BLOCKED);
+
+    eos_task_wake_check(0x0u);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_READY);
+
+    g_tick = 0;
+    printf("[PASS] wake deadline of zero\n");
+}
+
+static void test_wait_forever_never_wakes(void) {
+    eos_kernel_init();
+    int h = eos_task_create("forever", test_entry, NULL, 5, 1024);
+    assert(h >= 0);
+
+    g_tick = 0xFFFFFF00u;
+    eos_task_block_with_timeout((eos_task_handle_t)h, EOS_WAIT_FOREVER);
+
+    eos_task_wake_check(0xFFFFFF01u);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_BLOCKED);
+    eos_task_wake_check(0x0u);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_BLOCKED);
+    eos_task_wake_check(0x7FFFFFFFu);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_BLOCKED);
+
+    /* Only an explicit unblock releases it. */
+    eos_task_unblock((eos_task_handle_t)h);
+    assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_READY);
+
+    g_tick = 0;
+    printf("[PASS] wait forever never wakes\n");
+}
+
+static void test_swtimer_wraparound(void) {
+    eos_kernel_init();
+    g_timer_fired = 0;
+
+    eos_swtimer_handle_t t;
+    assert(eos_swtimer_create(&t, "wrap", 1000, false, wrap_timer_cb, NULL) == EOS_KERN_OK);
+
+    g_tick = 0xFFFFFF00u;
+    assert(eos_swtimer_start(t) == EOS_KERN_OK);
+
+    /* A one-shot timer must not fire on the very next tick. */
+    eos_swtimer_tick(0xFFFFFF01u);
+    assert(g_timer_fired == 0);
+
+    eos_swtimer_tick(0x2E7u);
+    assert(g_timer_fired == 0);
+
+    eos_swtimer_tick(0x2E8u);
+    assert(g_timer_fired == 1);
+
+    g_tick = 0;
+    printf("[PASS] swtimer wraparound\n");
+}
+
 /* Mock port functions for host-based simulation/testing */
 uint32_t eos_port_enter_critical(void) { return 0; }
 void eos_port_exit_critical(uint32_t state) { (void)state; }
@@ -154,6 +268,10 @@ int main(void) {
     test_semaphore();
     test_queue();
     test_queue_full();
-    printf("=== ALL KERNEL TESTS PASSED (9/9) ===\n");
+    test_wake_tick_wraparound();
+    test_wake_deadline_of_zero();
+    test_wait_forever_never_wakes();
+    test_swtimer_wraparound();
+    printf("=== ALL KERNEL TESTS PASSED (13/13) ===\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

`g_tick` is a free-running `uint32_t`, and deadlines are computed as
`g_tick + timeout`. Deadlines therefore wrap, roughly every 49.7 days at 1 ms
per tick.

Comparing a wrapped deadline with a plain `>=` is wrong, and using `0` as the
"wait forever" sentinel collides with a deadline that legitimately lands on
`0`. Two bugs, one root cause.

## What is wrong, part 1: tasks wake about 49.7 days early

`eos_task_wake_check()` used an absolute comparison:

```c
if (t->state == EOS_TASK_BLOCKED && t->wake_tick > 0 &&
    current_tick >= t->wake_tick) {
```

Once the deadline wraps past `UINT32_MAX`, that test is satisfied
immediately:

```
   tick counter, 32 bits wide
   0                                                    0xFFFFFFFF
   ├─────────────────────────────────────────────────────────────┤
                                                    ▲          ▲
                                                    │          │
                                      g_tick = 0xFFFFFF00      │
                                                               │
   eos_task_delay_ms(1000)                                     │
   wake_tick = 0xFFFFFF00 + 1000  ──── wraps around ───────────┘
                                                     │
   ┌─────────────────────────────────────────────────┘
   ▼
   wake_tick = 0x000002E8   (near the start of the range)

   next tick:  current_tick = 0xFFFFFF01

       0xFFFFFF01 >= 0x000002E8   is TRUE   ────►  task released

   intended wait:  1000 ticks
   actual wait:    1 tick
```

`eos_swtimer_tick()` had the identical test, reached through
`eos_swtimer_start()` and `eos_swtimer_reset()`, so a one-shot timer created
near the wrap fired on the very next tick instead of after its period.

## What is wrong, part 2: a bounded wait becomes unbounded

`eos_task_block_with_timeout()` stored `0` to mean `EOS_WAIT_FOREVER`, and
`eos_task_wake_check()` skipped any task whose `wake_tick` was `0`. But
`g_tick + timeout_ms` can land on `0` for real:

```
   g_tick   = 0xFFFFFF00
   timeout  = 0x100
   ─────────────────────
   wake_tick = 0x00000000     a legitimate deadline

   eos_task_wake_check() sees wake_tick == 0,
   reads it as "wait forever", and never wakes the task.
```

A finite `eos_mutex_lock(m, 256)`, `eos_sem_wait(s, 256)` or
`eos_queue_receive(q, &x, 256)` blocks forever. The window is narrow, but on
a device that runs for months it is a hang with no diagnostic and no timeout
to recover from.

## Why it matters

Tick wraparound is not a theoretical concern for this kernel. At the 1 ms
tick rate the code assumes, `g_tick` wraps every 49.7 days, which is well
inside the uptime an embedded device is expected to reach. A product that
passes every test on the bench can start releasing tasks early, or hanging on
a bounded wait, after seven weeks of continuous running.

Both faults are silent. Neither logs anything or returns an error.

## How it is fixed

Two changes, both standard RTOS practice.

**Compare the signed difference, not the values.** A new helper in
`kernel_internal.h`:

```c
#define EOS_TICK_REACHED(now, deadline) ((int32_t)((uint32_t)(now) - (uint32_t)(deadline)) >= 0)
```

Subtracting first and interpreting the result as signed makes the comparison
relative rather than absolute, so it stays correct across the wrap:

```
   g_tick = 0xFFFFFF00, wake_tick = 0x000002E8

   now = 0xFFFFFF01   (int32_t)(0xFFFFFF01 - 0x000002E8) = -999   not yet
   now = 0x000002E7   (int32_t)(0x000002E7 - 0x000002E8) =   -1   not yet
   now = 0x000002E8   (int32_t)(0x000002E8 - 0x000002E8) =    0   fire
```

This is correct for any deadline less than 2^31 ticks ahead, about 24.9 days
at 1 ms per tick, which comfortably exceeds any timeout the API can express
other than `EOS_WAIT_FOREVER`.

**Move "no timeout" out of the value space.** `eos_task_t` gains a
`wake_armed` flag, so every `uint32_t` is usable as a deadline again:

```
   before                                after
   ──────                                ─────
   wake_tick == 0  ►  "wait forever"     wake_armed == 0  ►  "wait forever"
   wake_tick != 0  ►  a deadline         wake_armed == 1  ►  wake_tick is a
                                                             deadline, and 0
                                                             is a valid one
```

The struct grows by one `uint8_t`. Both places that create or reset a task,
`eos_kernel_init()` and `eos_task_create()`, already `memset`, so the flag
starts cleared with no extra initialisation.

## Testing

Four tests added to `tests/test_kernel.c`, already a registered CTest target
that carries its own `eos_port_*` mocks, so it links standalone on the host.

I ran each one individually against unmodified kernel sources, keeping the
new tests, to establish exactly what fails without the fix:

| Test | Against the unfixed kernel |
|---|---|
| `test_wake_tick_wraparound` | **FAILS**, `eos_task_get_state(...) == EOS_TASK_BLOCKED` (woke after 1 tick instead of 1000) |
| `test_wake_deadline_of_zero` | **FAILS**, `eos_task_get_state(...) == EOS_TASK_READY` (never woke at all) |
| `test_swtimer_wraparound` | **FAILS**, `g_timer_fired == 0` (one-shot timer fired immediately) |
| `test_wait_forever_never_wakes` | passes, because it is a **control**, not a regression test |

That last row is deliberate. It exists to prove the fix does not accidentally
make `EOS_WAIT_FOREVER` wakeable, so it should pass both before and after. I
would rather label it honestly than imply four regressions where there are
three.

With the fix:

```
$ cmake -B build -DEOS_BUILD_TESTS=ON && cmake --build build --parallel
$ ./build/tests/test_kernel
...
[PASS] wake tick wraparound
[PASS] wake deadline of zero
[PASS] wait forever never wakes
[PASS] swtimer wraparound
=== ALL KERNEL TESTS PASSED (13/13) ===
```

Full suite: **21 of 21 CTest targets pass.** No new compiler warnings.

The tests reach `g_tick`, `eos_task_wake_check`, `eos_swtimer_tick`,
`eos_task_block_with_timeout` and `eos_task_unblock` through `extern`
declarations rather than including `kernel_internal.h`, following the
precedent already set in `tests/test_e2e.c:20-21`. That header says it is for
kernel sources only and I did not want to undercut it from a test.

## Limitations, and things I noticed but left alone

**The `test-host` CI job is already failing on `master`.** The E2E step
compiles with `-Werror`, and `tests/test_e2e.c` produces five errors:
`eos_tick_get` used but never declared, plus `-Wsign-compare` and
`-Wmisleading-indentation`. I reproduced this on a clean `master` checkout,
so it predates this PR and is not fixed by it. Flagging it so this change is
not blamed for a red check. Worth its own PR.

**I did not run the ARM cross-compile or the QEMU boot test.** Both need
`gcc-arm-none-eabi` and `qemu-system-arm`, which I did not have. The change
is portable C with no arch-specific content and `kernel/src/arch/arm_cm/` is
untouched, but to be clear about what I actually executed: host build only,
gcc 9.4 and CMake 3.16 on Ubuntu.

**The 24.9-day ceiling is a real constraint, not a hidden one.** Signed
difference comparison assumes deadlines sit within half the counter range.
Any future API that lets a caller request a timeout beyond roughly 2^31 ticks
would need a different scheme. That limit is documented on the macro.

**`eos_task_delete` still leaks its stack.** `alloc_task_stack` is a bump
allocator with no free list, so repeated create and delete exhausts
`g_stack_pool`. Noticed while reading `task.c`. Entirely separate, not
touched here.

## Pre-submission checklist

- [x] Builds without new warnings
- [x] All 21 existing CTest targets pass
- [x] New tests added, each regression test individually confirmed to fail without the change
- [x] Doxygen comments updated where behaviour changed
- [x] Commit signed off (DCO)
