### PR TITLE
fix(kernel): return invalid task name for deleted task handles

### DIFF
--- a/kernel/src/task.c
+++ b/kernel/src/task.c
@@ -360,7 +360,9 @@ eos_task_state_t eos_task_get_state(eos_task_handle_t h)
 
 const char *eos_task_get_name(eos_task_handle_t h)
 {
-    if (h >= EOS_MAX_TASKS || !g_tasks[h].name) return "invalid";
+    if (h >= EOS_MAX_TASKS || g_tasks[h].state == EOS_TASK_DELETED || !g_tasks[h].name) {
+        return "invalid";
+    }
     return g_tasks[h].name;
 }
 

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -34,8 +34,10 @@ static void test_task_create_invalid(void) {
 static void test_task_delete(void) {
     eos_kernel_init();
     int h = eos_task_create("del", test_entry, NULL, 5, 1024);
+    assert(strcmp(eos_task_get_name((eos_task_handle_t)h), "del") == 0);
     assert(eos_task_delete((eos_task_handle_t)h) == EOS_KERN_OK);
     assert(eos_task_get_state((eos_task_handle_t)h) == EOS_TASK_DELETED);
+    assert(strcmp(eos_task_get_name((eos_task_handle_t)h), "invalid") == 0);
     printf("[PASS] task delete\n");
 }
 


### PR DESCRIPTION
ISSUE:
In `kernel/src/task.c`, `eos_task_get_name()` previously only verified if the handle index was within bounds and if `g_tasks[h].name` was non-null. When a task was deleted via `eos_task_delete()`, its name pointer remained intact in the TCB while its state transitioned to `EOS_TASK_DELETED`. Calling `eos_task_get_name()` on a deleted task handle incorrectly returned the stale name instead of `"invalid"`.

APPROACH:
- Updated `eos_task_get_name()` in `kernel/src/task.c` to check `g_tasks[h].state == EOS_TASK_DELETED` alongside bounds and null checks, safely returning `"invalid"` for terminated tasks.
- Updated `test_task_delete()` in `tests/test_kernel.c` with assertions confirming `eos_task_get_name()` resolves to the task name before deletion and transitions to `"invalid"` following `eos_task_delete()`.

TESTING & VALIDATION PERFORMED:
- Built host test binaries using CMake (`cmake -B build/host -DEOS_BUILD_TESTS=ON && cmake --build build/host --parallel`).
- Executed full test suite via CTest: 21/21 tests passed (100% pass rate).
- Verified `test_kernel` passes with the new post-deletion assertion.

LIMITATIONS:
- Non-breaking change ensuring robust state validation for deleted tasks.