### PR TITLE
feat: add HiLetGo ESP32 board support

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -158,6 +158,14 @@ nrfjprog --reset
 esptool.py --chip esp32 write_flash 0x10000 build/eos.bin
 ```
 
+The HiLetGo ESP-WROOM-32 ESP-32S is represented by the
+`boards/hiletgo-esp-wroom-32.yaml` descriptor and reuses the existing ESP32
+(`ESP32-D0WDQ6`, LX6) target definition. EoS does not currently provide an
+Xtensa ESP32 cross-toolchain file or an ESP32 firmware build target, so this
+descriptor does not by itself produce a flashable image. Install and configure
+the Espressif ESP32 toolchain and validate the generated image and flash
+addresses for the specific module before programming hardware.
+
 ---
 
 ## Build eBoot Separately

--- a/boards/hiletgo-esp-wroom-32.yaml
+++ b/boards/hiletgo-esp-wroom-32.yaml
@@ -1,0 +1,33 @@
+# EoS Board: HiLetGo ESP-WROOM-32 ESP32 ESP-32S
+board:
+  name: hiletgo-esp-wroom-32
+  mcu: ESP32-D0WDQ6
+  family: ESP32
+  arch: xtensa
+  core: lx6
+  vendor: Espressif
+  clock_hz: 240000000
+  memory:
+    flash: 4194304
+    ram: 532480
+  peripherals:
+    - {name: UART0, type: uart, bus: peripheral}
+    - {name: UART1, type: uart, bus: peripheral}
+    - {name: SPI2, type: spi, bus: peripheral}
+    - {name: SPI3, type: spi, bus: peripheral}
+    - {name: I2C0, type: i2c, bus: peripheral}
+    - {name: I2C1, type: i2c, bus: peripheral}
+    - {name: GPIO, type: gpio, bus: peripheral}
+    - {name: ADC1, type: adc, bus: peripheral}
+    - {name: ADC2, type: adc, bus: peripheral}
+    - {name: DAC, type: dac, bus: peripheral}
+    - {name: PWM, type: pwm, bus: peripheral}
+    - {name: WIFI, type: wifi, bus: peripheral}
+    - {name: BLE, type: ble, bus: peripheral}
+    - {name: CAN, type: can, bus: peripheral}
+    - {name: DMA, type: dma, bus: system}
+    - {name: WDT, type: watchdog, bus: peripheral}
+    - {name: RTC, type: rtc, bus: peripheral}
+    - {name: TOUCH, type: touch, bus: peripheral}
+  features: [dual_core]
+  supply_voltage: 3.3

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,11 @@
 # EoS Unit Tests
+# --- test_board_configs: Board YAML schema shape ---
+add_executable(test_board_configs test_board_configs.c)
+add_test(NAME test_board_configs COMMAND test_board_configs boards)
+set_tests_properties(test_board_configs PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
 # --- test_config: OS configuration ---
 add_executable(test_config test_config.c)
 target_link_libraries(test_config PRIVATE eos_core)

--- a/tests/test_board_configs.c
+++ b/tests/test_board_configs.c
@@ -58,6 +58,165 @@ static int file_contains(const char *path, const char *needle) {
     return 0;
 }
 
+static int file_contains_text(const char *path, const char *needle) {
+    if (!path || path[0] == '\0' || !needle || needle[0] == '\0') return 0;
+
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+
+    char line[1024];
+    while (fgets(line, sizeof(line), f)) {
+        char *content = line;
+        while (isspace((unsigned char)*content)) content++;
+        if (*content != '#' && strstr(content, needle)) {
+            fclose(f);
+            return 1;
+        }
+    }
+    fclose(f);
+    return 0;
+}
+
+static char *trim_whitespace(char *text) {
+    char *end;
+    while (isspace((unsigned char)*text)) text++;
+    end = text + strlen(text);
+    while (end > text && isspace((unsigned char)end[-1])) end--;
+    *end = '\0';
+    return text;
+}
+
+static int parse_key_value(char *text, char **key, char **value) {
+    char *colon = strchr(text, ':');
+    if (!colon) return 0;
+    *colon = '\0';
+    *key = trim_whitespace(text);
+    *value = trim_whitespace(colon + 1);
+    return (*key)[0] != '\0';
+}
+
+static int supported_peripheral_type(const char *type) {
+    static const char *types[] = {
+        "uart", "spi", "i2c", "can", "usb", "adc", "dac", "pwm",
+        "timer", "gpio", "ethernet", "wifi", "ble", "camera", "display",
+        "sdio", "watchdog", "rtc", "dma", "motor", "nfc", "gps", "imu",
+        "audio", "hdmi", "gpu", "pcie", "cellular", "ir", "radar", "haptic",
+        "touch", "flash_ctrl", NULL
+    };
+    for (int i = 0; types[i]; i++) {
+        if (strcmp(type, types[i]) == 0) return 1;
+    }
+    return 0;
+}
+
+static int validate_peripheral_record(char *text, int *peripheral_count) {
+    static const char *expected_names[] = {
+        "UART0", "UART1", "SPI2", "SPI3", "I2C0", "I2C1", "GPIO", "ADC1",
+        "ADC2", "DAC", "PWM", "WIFI", "BLE", "CAN", "DMA", "WDT", "RTC", "TOUCH"
+    };
+    static const char *expected_types[] = {
+        "uart", "uart", "spi", "spi", "i2c", "i2c", "gpio", "adc", "adc", "dac",
+        "pwm", "wifi", "ble", "can", "dma", "watchdog", "rtc", "touch"
+    };
+    char *fields[3] = {0};
+    char *field;
+    int field_count = 0;
+
+    text = trim_whitespace(text);
+    if (text[0] != '-' || text[1] != ' ') return 0;
+    text = trim_whitespace(text + 2);
+    if (strlen(text) < 2 || text[0] != '{' || text[strlen(text) - 1] != '}') return 0;
+    text[strlen(text) - 1] = '\0';
+    text = trim_whitespace(text + 1);
+    while ((field = strtok(field_count == 0 ? text : NULL, ",")) != NULL) {
+        if (field_count >= 3) return 0;
+        fields[field_count++] = trim_whitespace(field);
+    }
+    if (field_count != 3 || *peripheral_count >= (int)(sizeof(expected_names) / sizeof(expected_names[0]))) {
+        return 0;
+    }
+
+    for (int i = 0; i < field_count; i++) {
+        char *key;
+        char *value;
+        if (!parse_key_value(fields[i], &key, &value)) return 0;
+        if (strcmp(key, "name") == 0 && strcmp(value, expected_names[*peripheral_count]) == 0) continue;
+        if (strcmp(key, "type") == 0 && strcmp(value, expected_types[*peripheral_count]) == 0 &&
+            supported_peripheral_type(value)) continue;
+        if (strcmp(key, "bus") == 0 && strcmp(value, (*peripheral_count == 14) ? "system" : "peripheral") == 0) continue;
+        return 0;
+    }
+    (*peripheral_count)++;
+    return 1;
+}
+
+static int validate_hiletgo_descriptor(const char *path) {
+    FILE *f = fopen(path, "r");
+    char line[1024];
+    unsigned int seen = 0;
+    int peripheral_count = 0;
+    const unsigned int required = (1u << 14) - 1u;
+
+    if (!f) return 0;
+    while (fgets(line, sizeof(line), f)) {
+        char *content;
+        char *key;
+        char *value;
+        size_t indent = 0;
+        line[strcspn(line, "\r\n")] = '\0';
+        content = line;
+        while (*content == ' ') { indent++; content++; }
+        content = trim_whitespace(content);
+        if (*content == '\0' || *content == '#') continue;
+        if (indent == 4 && content[0] == '-') {
+            if (!(seen & (1u << 10)) || !validate_peripheral_record(content, &peripheral_count)) {
+                fclose(f);
+                return 0;
+            }
+            continue;
+        }
+        if ((indent != 0 && indent != 2 && indent != 4) || !parse_key_value(content, &key, &value)) {
+            fclose(f);
+            return 0;
+        }
+        if (indent == 0 && strcmp(key, "board") == 0 && value[0] == '\0') {
+            if (seen & (1u << 13)) { fclose(f); return 0; }
+            seen |= 1u << 13;
+        } else if (indent == 2 && strcmp(key, "name") == 0 && strcmp(value, "hiletgo-esp-wroom-32") == 0) {
+            if (seen & (1u << 0)) { fclose(f); return 0; } seen |= 1u << 0;
+        } else if (indent == 2 && strcmp(key, "mcu") == 0 && strcmp(value, "ESP32-D0WDQ6") == 0) {
+            if (seen & (1u << 1)) { fclose(f); return 0; } seen |= 1u << 1;
+        } else if (indent == 2 && strcmp(key, "family") == 0 && strcmp(value, "ESP32") == 0) {
+            if (seen & (1u << 2)) { fclose(f); return 0; } seen |= 1u << 2;
+        } else if (indent == 2 && strcmp(key, "arch") == 0 && strcmp(value, "xtensa") == 0) {
+            if (seen & (1u << 3)) { fclose(f); return 0; } seen |= 1u << 3;
+        } else if (indent == 2 && strcmp(key, "core") == 0 && strcmp(value, "lx6") == 0) {
+            if (seen & (1u << 4)) { fclose(f); return 0; } seen |= 1u << 4;
+        } else if (indent == 2 && strcmp(key, "vendor") == 0 && strcmp(value, "Espressif") == 0) {
+            if (seen & (1u << 5)) { fclose(f); return 0; } seen |= 1u << 5;
+        } else if (indent == 2 && strcmp(key, "clock_hz") == 0 && strcmp(value, "240000000") == 0) {
+            if (seen & (1u << 6)) { fclose(f); return 0; } seen |= 1u << 6;
+        } else if (indent == 2 && strcmp(key, "memory") == 0 && value[0] == '\0') {
+            if (seen & (1u << 7)) { fclose(f); return 0; } seen |= 1u << 7;
+        } else if (indent == 4 && strcmp(key, "flash") == 0 && strcmp(value, "4194304") == 0) {
+            if (seen & (1u << 8)) { fclose(f); return 0; } seen |= 1u << 8;
+        } else if (indent == 4 && strcmp(key, "ram") == 0 && strcmp(value, "532480") == 0) {
+            if (seen & (1u << 9)) { fclose(f); return 0; } seen |= 1u << 9;
+        } else if (indent == 2 && strcmp(key, "peripherals") == 0 && value[0] == '\0') {
+            if (seen & (1u << 10)) { fclose(f); return 0; } seen |= 1u << 10;
+        } else if (indent == 2 && strcmp(key, "features") == 0 && strcmp(value, "[dual_core]") == 0) {
+            if (seen & (1u << 11)) { fclose(f); return 0; } seen |= 1u << 11;
+        } else if (indent == 2 && strcmp(key, "supply_voltage") == 0 && strcmp(value, "3.3") == 0) {
+            if (seen & (1u << 12)) { fclose(f); return 0; } seen |= 1u << 12;
+        } else {
+            fclose(f);
+            return 0;
+        }
+    }
+    fclose(f);
+    return seen == required && peripheral_count == 18;
+}
+
 static const char *required_fields[] = {
     "name:",
     "arch:",
@@ -68,9 +227,45 @@ static const char *valid_arches[] = {
     "arm64", "cortex-m", "cortex-m4", "cortex-m7", "cortex-r",
     "cortex-a", "x86", "x86_64", "riscv32", "riscv64",
     "mips", "powerpc", "sparc", "sh", "m68k", "h8300",
-    "mn103", "v850", "frv", "strongarm", "xscale", "host",
+    "mn103", "v850", "frv", "strongarm", "xscale", "xtensa", "host",
     NULL
 };
+
+static void validate_hiletgo_esp32_alias(const char *dir) {
+    const char *filename = "hiletgo-esp-wroom-32.yaml";
+    char full_path[PATH_LIMIT];
+
+    if (!dir || snprintf(full_path, sizeof(full_path), "%s/%s", dir, filename) >= (int)sizeof(full_path)) {
+        tests_run++;
+        printf("  %-50s [FAIL] path too long\n", filename);
+        tests_failed++;
+        return;
+    }
+
+    tests_run++;
+    printf("  %-50s ", "HiLetGo ESP-WROOM-32 compatibility");
+    if (!file_exists(full_path)) {
+        printf("[FAIL] file not found\n");
+        tests_failed++;
+        return;
+    }
+
+    if (!validate_hiletgo_descriptor(full_path)) {
+        printf("[FAIL] descriptor structure or values are invalid\n");
+        tests_failed++;
+        return;
+    }
+
+    if (file_contains_text(full_path, "type: usb") ||
+        file_contains_text(full_path, "name: USB")) {
+        printf("[FAIL] native USB must not be advertised\n");
+        tests_failed++;
+        return;
+    }
+
+    tests_passed++;
+    printf("[PASS]\n");
+}
 
 static void validate_board(const char *dir, const char *filename) {
     char full_path[PATH_LIMIT];
@@ -81,6 +276,9 @@ static void validate_board(const char *dir, const char *filename) {
     }
     
     if (snprintf(full_path, sizeof(full_path), "%s/%s", dir, filename) >= (int)sizeof(full_path)) {
+        tests_run++;
+        printf("  %-50s [FAIL] path too long\n", filename);
+        tests_failed++;
         return;
     }
 
@@ -179,6 +377,7 @@ int main(int argc, char *argv[]) {
     printf("  Scanning: %s\n\n", final_dir);
 
     scan_directory(final_dir);
+    validate_hiletgo_esp32_alias(final_dir);
 
     if (tests_run == 0) {
         printf("  [SKIP] No yaml files found in '%s'\n", final_dir);


### PR DESCRIPTION
## Issue, Bug, or Improvement

Add board support metadata for the HiLetGo ESP-WROOM-32 ESP32 ESP-32S module so it can be selected and validated as an ESP32 Xtensa LX6 board configuration.

## Proposed Approach and Implementation

- Added boards/hiletgo-esp-wroom-32.yaml
- Avoided advertising native USB; these boards typically use an external USB-to-UART bridge
- Added strict descriptor-specific validation for required YAML records, indentation, duplicates, schema values, peripheral mappings, and native USB absence
- Registered the board validation executable with CTest
- Documented that this repository does not currently contain an Xtensa firmware build target or flashing integration

## Testing and Validation

- PASS: Independent code review.
- PASS: Descriptor/schema contract checks by inspection.
- PASS: git diff --check.

## Additional Considerations and Limitations

- The descriptor targets the common ESP32-D0WDQ6 ESP-WROOM-32 profile; module flash size and exact board revision should be confirmed against the physical board before flashing.
- This PR adds board metadata and validation, not a complete ESP-IDF-compatible firmware port or flashing workflow.
- The PR is submitted from a fork because the authenticated account does not have write permission to the upstream repository.