### PR TITLE
docs(adr): record the third-party adoption decisions (ADR-012..019)

### DIFF
--- a/docs/adr/ADR-012-cryptographic-provider-selection.md
+++ b/docs/adr/ADR-012-cryptographic-provider-selection.md
@@ -1,0 +1,97 @@
+---
+adr: 12
+title: Cryptographic provider selection
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), Boot & Security maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §4, §8, §11, §21, §25
+supersedes: none
+closes: ADR-011 "Open" item 1 — which provider, and what it costs in flash
+---
+
+# ADR-012 — Cryptographic provider selection
+
+**Status: Proposed.** ADR-011 decided that no cryptographic primitive is implemented in
+this organisation. It left the provider unchosen. This record chooses one.
+
+## Context
+
+The gap ADR-011 documented is still open, and a contributor has now tried to close it by
+hand.
+
+**Observed — the tree as it stands on `master`:**
+
+| Location | State |
+|---|---|
+| `eos/services/crypto/` | Four hand-written implementations: `aes.c`, `sha256.c`, `rsa_ecc_sha512.c`, `crc.c` |
+| `eBoot/core/` | A second, independent SHA-512 and a hand-rolled Ed25519 verify |
+| Third-party crypto anywhere in `eos` | **None.** A tree scan for vendored dependencies returns nothing |
+
+**Observed — `eos` PR #57** proposes a third set: 4,815 added lines of vendored Curve25519
+field arithmetic, precomputed tables and a third SHA-512. A search of that diff for
+`copyright`, `license`, or `public domain` returns **zero matches**, and it adds no test
+vectors for the verification path it introduces.
+
+PR #57 has the right instinct and the wrong execution. ADR-011 item 2 says to delete the
+hand-rolled Ed25519 and link a reviewed implementation — not to paste an unattributed one
+into the tree. The distinction that matters is *provenance*: a reviewed provider is
+reviewed because it is identifiable, versioned, and tracked for advisories. A copy with no
+upstream reference has none of those properties, whatever its origin.
+
+## Decision
+
+1. **Mbed TLS is the provider for `eos`**, consumed through the **PSA Crypto API** rather
+   than the legacy `mbedtls_*` interface. PSA is the interface silicon vendors map their
+   hardware accelerators to, so the same call reaches a software implementation on one part
+   and a crypto co-processor on another. `eos/services/crypto/include/eos/crypto.h` stays
+   as the EoS-facing API and becomes a thin shim over PSA.
+
+2. **eBoot links a verify-only subset.** The bootloader takes the smallest reviewed
+   configuration that provides SHA-512 and Ed25519 verification — Mbed TLS with everything
+   else compiled out. No signing, no TLS, no AEAD in the boot chain.
+
+3. **Deletion, not coexistence.** When PSA covers a primitive, the hand-written file is
+   deleted in the same commit. A hand-rolled implementation that stays in the tree "for
+   reference" is one `#include` away from being linked again.
+
+4. **CRC-32 is out of scope.** It is not a cryptographic primitive and stays as it is.
+
+5. **No import without conformance vectors in CI.** Per ADR-011 item 4, each adopted
+   primitive lands with published vectors (FIPS 180-4, FIPS-197, RFC 8032 §7.1) executing
+   in the test suite. The RFC 8032 vectors that currently fail become the acceptance test
+   for this work.
+
+6. **PR #57 is closed in favour of this record**, with thanks — it identified a real defect
+   that ADR-011 had documented and nothing had acted on.
+
+## Consequences
+
+- **Footprint is the real cost and it is not yet measured.** ADR-011 named this and it
+  remains unquantified. Before this ADR moves to Accepted, flash and RAM deltas must be
+  measured on the smallest §21 Nano target, in both the eBoot verify-only and the full
+  `eos` configuration. *This is a blocking prerequisite, not a follow-up.*
+- **License obligation.** Mbed TLS is Apache-2.0 (**Inferred**, re-check at import).
+  Apache-2.0 combines with this MIT project but carries attribution requirements, so
+  ADR-017's `NOTICE` and SBOM work must land first.
+- Ed25519 secure boot becomes functional for the first time. Until it does, §25 status for
+  `EOS_SIG_ED25519` stays **non-functional** exactly as ADR-011 requires.
+- Anything ever signed with a key whose signatures nothing could verify remains an open
+  question inherited from ADR-011 and is not resolved here.
+
+## Alternatives considered
+
+- **BearSSL** — smaller and constant-time by construction, but a narrower ecosystem and no
+  PSA mapping, which forfeits the hardware-accelerator argument that motivates this choice.
+- **libsodium verify-only** — excellent for the eBoot half, but does not cover the AES and
+  RSA surface `eos` exposes, so it would mean two providers.
+- **wolfSSL** — GPLv2-or-commercial. **Rejected**: incompatible with shipping an MIT
+  runtime without a commercial licence.
+- **Repair the existing code** — explicitly rejected by ADR-011 item 2, and that reasoning
+  is adopted unchanged here.
+
+## Open
+
+- Measured flash/RAM cost on the smallest supported part (blocking, see above).
+- Whether `eos`'s RSA/ECDSA stubs are deleted outright or migrated, inherited from ADR-011.
+- Whether the PSA shim can be thin enough that `eos/crypto.h` needs no source changes in
+  callers. **Unknown** until attempted.

--- a/docs/adr/ADR-013-devicetree-via-libfdt.md
+++ b/docs/adr/ADR-013-devicetree-via-libfdt.md
@@ -1,0 +1,51 @@
+---
+adr: 13
+title: Flattened device tree parsing via libfdt
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), Kernel & Drivers maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §7.1, §26
+---
+
+# ADR-013 — Flattened device tree parsing via libfdt
+
+## Context
+
+`drivers/devicetree/devicetree.c` is a hand-written FDT walker. A device tree blob is
+untrusted input: it arrives from a prior boot stage or a flash region, and every offset and
+length inside it is chosen by whoever produced it.
+
+**Observed:** `eos` PR #50 is currently re-deriving, by hand, the bounds checks that a
+standard FDT library has had for years — validated `totalsize`, per-token bounds, NUL
+termination inside the blob, a nesting-depth cap. The PR is careful and well documented.
+It is also work the project should not have to do, review, or maintain.
+
+Every Linux, U-Boot, Zephyr and Barebox target already produces and consumes FDT blobs.
+The format is not ours; the parser should not be either.
+
+## Decision
+
+1. **Adopt `libfdt`** (from the `dtc` project) as the FDT parser for both `eos` and
+   `eBoot`, taking the **BSD-2-Clause** arm of its dual licence. **Inferred** — confirm the
+   dual-licence grant at import and record it per ADR-017.
+2. `drivers/devicetree/devicetree.h` stays as the EoS-facing API; the `.c` becomes a shim
+   over libfdt and the hand-written walker is deleted.
+3. **The test corpus from PR #50 is kept and retargeted.** Its truncation sweep and
+   single-byte-corruption sweep are valuable regardless of what sits underneath, and they
+   become the acceptance test for the shim. The fuzz target it enables stays enabled.
+
+## Consequences
+
+- PR #50's parser changes become unnecessary. Its tests and its `tests/fuzz` wiring do not
+  — that wiring fixes a directory no `add_subdirectory` had ever included, which is worth
+  merging on its own regardless of this ADR's outcome.
+- libfdt is read-oriented and allocation-free, which suits the Nano profile. Footprint is
+  **Unknown** here and must be measured alongside ADR-012's crypto budget.
+- Consuming vendor-published DTS files becomes possible, which is the precondition for
+  ADR-016.
+
+## Open
+
+- Whether `eBoot` needs the full libfdt or only `fdt_ro.c`.
+- Whether to also adopt `dtc` itself as a build-time dependency for compiling DTS → DTB, or
+  to require a pre-built blob. ADR-016 depends on the answer.

--- a/docs/adr/ADR-014-tcpip-via-lwip.md
+++ b/docs/adr/ADR-014-tcpip-via-lwip.md
@@ -1,0 +1,59 @@
+---
+adr: 14
+title: TCP/IP via lwIP
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), Networking maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §12, §21, §25
+---
+
+# ADR-014 — TCP/IP via lwIP
+
+## Context
+
+§12 describes eNet as covering TCP/IP, UDP, DHCP, DNS, MQTT, CoAP, HTTP and WebSocket.
+
+**Observed — what `net/src/net.c` actually contains:** 184 lines, in which
+`eos_net_connect()` is
+
+```c
+int eos_net_connect(eos_socket_t sock, const eos_net_addr_t *addr)
+{
+    (void)sock; (void)addr;
+    return -1;
+}
+```
+
+and `eos_net_socket()` returns an incrementing integer. There is no protocol
+implementation of any kind. `eos` PR #53 adds protocol-argument validation to this
+facade — a correct fix to a function that connects nothing.
+
+This is the clearest case in the tree where adoption costs nothing, because there is no
+existing implementation to preserve.
+
+## Decision
+
+1. **Adopt lwIP** as the TCP/IP stack for the Nano and Edge profiles. BSD-3-Clause
+   (**Inferred**; confirm at import).
+2. `net/include/eos/net.h` stays as the EoS-facing API. The socket-shaped functions map
+   onto lwIP's sockets or raw API depending on profile.
+3. On the Compute profile, where a host OS is present, the same API maps to POSIX sockets.
+4. **§25 status for eNet is corrected to `Planned` in the same PR that merges this ADR.**
+   Documenting a stub as a networking subsystem is the failure mode §25 exists to prevent,
+   and correcting the record does not wait for the implementation.
+5. MQTT, CoAP and HTTP are **not** in scope here. They are separate adoption decisions on
+   top of a working IP stack.
+
+## Consequences
+
+- lwIP is materially larger than 184 lines of stub. The Nano profile must be able to build
+  without it; that is a Kconfig question and therefore depends on ADR-016.
+- lwIP is already integrated by ST, Espressif, NXP and TI, so vendor porting layers exist
+  for the reference boards named in the Phase 3 plan.
+- PR #53's validation remains correct and harmless under the shim.
+
+## Open
+
+- Which lwIP integration mode — `NO_SYS=1` bare-metal, or the RTOS mode backed by EoS
+  tasks. The RTOS mode is the better fit but requires the CMSIS-RTOS2 surface of ADR-015.
+- Zero-copy buffer ownership across the EoS API boundary. **Unknown**; needs a design pass.

--- a/docs/adr/ADR-015-vendor-hal-adapter-policy.md
+++ b/docs/adr/ADR-015-vendor-hal-adapter-policy.md
@@ -1,0 +1,61 @@
+---
+adr: 15
+title: Vendor HAL adapter policy
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), HAL & BSP maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §3, §7.1, §22, §31
+---
+
+# ADR-015 — Vendor HAL adapter policy
+
+## Context
+
+**Observed:** `hal/src/hal_stm32f4/` contains hand-written GPIO, UART, SPI, I²C, ADC, RCC
+and timer drivers — register-level code derived from a reference manual. It is the only
+vendor family implemented to that depth.
+
+**Observed:** `boards/` holds 88 YAML profiles, of which the large majority are named
+`generic-<arch>` — `generic-arm7tdmi`, `generic-avr32`, `generic-c166`, and so on. Breadth
+in the file listing; almost none of it is a real port.
+
+The two observations have the same cause. Supporting a part currently means re-deriving a
+vendor's peripheral programming by hand, so the marginal cost of each new part is measured
+in weeks and nothing gets past the placeholder stage.
+
+Silicon vendors already publish, maintain and test that layer: CMSIS-Core headers plus
+STM32Cube HAL, nrfx, ESP-IDF, MCUXpresso, TI MCU+SDK.
+
+## Decision
+
+1. **The EoS HAL API does not change.** `hal/include/eos/hal.h` remains the contract that
+   drivers and applications compile against.
+2. **Below it, EoS adapts rather than reimplements.** Each supported family gets a thin
+   adapter translating the EoS HAL onto CMSIS-Core plus that vendor's own SDK.
+3. **Register-level drivers are written only where no vendor SDK exists**, and that
+   exception is recorded in the board profile.
+4. **The existing STM32F4 implementation is not deleted.** It becomes the reference against
+   which the first STM32Cube adapter is differentially tested — the same peripheral, two
+   implementations, compared on hardware. Once the adapter passes, the hand-written version
+   is removed in a separate commit.
+5. **A board profile may not claim support without a passing CI job.** `boards/*.yaml`
+   entries without one are marked `status: placeholder` in the same PR that merges this
+   ADR.
+
+## Consequences
+
+- Adding a vendor becomes adapter work rather than a port, which is what makes the §31
+  goal of real reference boards reachable.
+- Vendor SDK licences enter the dependency tree (Apache-2.0 and BSD-3 typically;
+  **Inferred**, and some vendor SDKs carry use-restriction clauses that must be read
+  individually). ADR-017 governs each import.
+- Build complexity rises: each family brings its own headers and startup code, and `ebuild`
+  must fetch them per target.
+- The 88-board list will shrink, visibly, when placeholders are labelled. That is the
+  intended outcome — an honest matrix is worth more to an evaluating vendor than a long one.
+
+## Open
+
+- Whether adapters live in `eos` or in per-vendor repositories. §22's split policy
+  (ADR-002) says not to split before an independent release lifecycle exists.
+- How vendor SDKs are pinned and fetched — ADR-017 and ADR-019 share this mechanism.

--- a/docs/adr/ADR-016-devicetree-and-kconfig.md
+++ b/docs/adr/ADR-016-devicetree-and-kconfig.md
@@ -1,0 +1,62 @@
+---
+adr: 16
+title: Board and feature description via devicetree and Kconfig
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), Build & Tooling maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §7.1, §9, §18, §31
+---
+
+# ADR-016 — Board and feature description via devicetree and Kconfig
+
+## Context
+
+Two bespoke description formats exist today, and both are load-bearing.
+
+**Board description — `boards/*.yaml`.** A format only this project reads. Nothing a
+vendor publishes can be imported into it, so every board is authored by hand. See ADR-015
+for what that has produced.
+
+**Feature selection — `EOS_ENABLE_*` preprocessor defines.** The top-level `CMakeLists.txt`
+carries a comment explaining that these must be set before any `add_library()` call,
+because a test defining a flag for itself is not enough — the flag has to reach the library
+translation unit too. That comment is a description of a configuration system that does not
+exist yet.
+
+**Observed:** `core/src/config.c`, the hand-written parser for the project's own YAML
+subset, is the source of two duplicate open PRs (#61, #65) for the same out-of-bounds
+write. Its regression test **segfaults** on unfixed `master` (**Verified** — the test from
+PR #61 run against `origin/master` exits 139). A bespoke format costs a bespoke parser, and
+a bespoke parser costs memory-safety defects.
+
+## Decision
+
+1. **Devicetree source is the board description format.** DTS in, compiled to DTB,
+   consumed via ADR-013's libfdt. Vendor-published DTS for an SoC or eval board becomes
+   importable rather than transcribable.
+2. **`boards/*.yaml` becomes a generated artifact**, derived from DTS, not hand-maintained
+   truth. It may continue to exist for tooling that reads it.
+3. **Kconfig replaces the `EOS_ENABLE_*` defines**, using `kconfiglib` at build time.
+   `ebuild configure` and EoStudio's board configurator render the Kconfig tree rather than
+   each modelling features their own way — which is §4's "do not duplicate build systems
+   between eBuild and EoStudio" applied to configuration.
+4. **`core/src/config.c` keeps its current scope** (project/package manifests) and is not
+   extended. PR #61 should still merge: the OOB write is real today and this ADR does not
+   land tomorrow.
+
+## Consequences
+
+- Board bring-up changes from authoring to importing. This is the single largest lever on
+  multi-vendor reach in this ADR set.
+- Contributors who know Zephyr find a familiar configuration model, which lowers the cost
+  of contributing a board.
+- A build-time Python dependency (`kconfiglib`) enters the toolchain. `ebuild doctor` must
+  check for it and say so plainly when it is missing.
+- The 88 board profiles must be triaged: import-backed, hand-written, or placeholder.
+
+## Open
+
+- Whether EoS defines its own DT bindings or reuses Zephyr's where they match. Reuse is
+  cheaper and interoperable; divergence may be unavoidable for EoS-specific nodes.
+- Migration path for the boards already described in YAML. **Unknown** until the triage
+  above is done.

--- a/docs/adr/ADR-017-third-party-and-sbom-policy.md
+++ b/docs/adr/ADR-017-third-party-and-sbom-policy.md
@@ -1,0 +1,70 @@
+---
+adr: 17
+title: Third-party dependency, vendoring and SBOM policy
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), all repository maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §4, §26
+---
+
+# ADR-017 — Third-party dependency, vendoring and SBOM policy
+
+**This ADR is a prerequisite for ADR-012 through ADR-016.** None of them may import
+anything until this one is Accepted.
+
+## Context
+
+**Observed:** `eos` contains **no third-party libraries at all** — a tree scan for the
+usual vendoring conventions and for any of the libraries this ADR set proposes returns
+nothing. There is consequently no policy for how one would be added, and no `sbom` in the
+repository.
+
+**Observed:** in the absence of a policy, `eos` PR #57 proposed adding 4,815 lines of
+third-party cryptographic code with no licence header, no attribution, no upstream
+reference and no pinned revision. That is not a contributor failure. It is what happens
+when a project with a `NOTICE` file and a `SECURITY.md` has never written down how to
+bring code in.
+
+§26 already requires "SBOM generation and dependency/license inventory". Nothing implements
+it.
+
+## Decision
+
+1. **`third_party/<name>/` is the only location for external source.** Each directory
+   contains the upstream source unmodified, plus:
+   - `UPSTREAM` — repository URL, exact tag or commit SHA, import date, importer.
+   - `LICENSE` — copied verbatim from upstream.
+   - `PATCHES/` — every local modification as a numbered patch file. Modifying vendored
+     source in place is prohibited; a change that cannot be expressed as a patch must be
+     sent upstream instead.
+2. **Pinned revisions only.** A branch name or floating ref is not a pin. Imports use CMake
+   `FetchContent` with a SHA, or a submodule, or a checked-in copy with the SHA recorded in
+   `UPSTREAM` — never a moving target.
+3. **`NOTICE` lists every import** with its licence, updated in the same commit.
+4. **Licence allow-list for anything linked into the runtime:** MIT, BSD-2, BSD-3,
+   Apache-2.0, ISC, Zlib, and public-domain dedications. **Copyleft licences (GPL, LGPL,
+   AGPL) are prohibited in linked runtime code.** Tools invoked as separate processes —
+   OpenOCD, dtc, QEMU — are unaffected by this rule, and the distinction must be recorded
+   per dependency.
+5. **`ebuild sbom` emits CycloneDX** covering every `third_party/` entry and every fetched
+   dependency, and release artifacts ship it. This closes the §26 requirement.
+6. **A new dependency needs an ADR.** Not a PR description — a record, naming what it
+   replaces and what it costs in flash and RAM.
+7. **Advisory tracking.** Each import carries an upstream watch so that a CVE reaches this
+   project as a task rather than as a customer report.
+
+## Consequences
+
+- PR #57 cannot merge in its present form, and now there is a written reason to point to
+  rather than a judgement call.
+- Every ADR in this set gains a blocking prerequisite. That is deliberate: importing first
+  and inventorying later is how licence obligations get missed.
+- Someone must own the advisory watch. An unowned watch is not a control.
+
+## Open
+
+- Submodules vs `FetchContent` vs checked-in copies. Each has a different offline-build
+  and reproducibility profile; §26 requires reproducible release builds, which argues for
+  checked-in or SHA-pinned fetch with a mirror.
+- Whether `third_party/` sits in each repository or in one shared repository consumed by
+  all. ADR-019 is the same question for first-party code.

--- a/docs/adr/ADR-018-test-framework.md
+++ b/docs/adr/ADR-018-test-framework.md
@@ -1,0 +1,67 @@
+---
+adr: 18
+title: Test framework and machine-readable CI results
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), QA maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §26, §31
+---
+
+# ADR-018 — Test framework and machine-readable CI results
+
+## Context
+
+**Observed:** the suite is hand-rolled `assert()` and `printf` per file, with a
+`main()` that prints a hard-coded total such as `ALL KERNEL TESTS PASSED (9/9)`. Three
+open PRs each edit that literal to a different number. A failing assertion aborts the
+process and reports nothing structured.
+
+**Verified — enumerated against `origin/master`, 28 Aug 2026:** **13 test files exist in
+`eos/tests/` that no `CMakeLists.txt` registers**, so they are never compiled and never
+run:
+
+`main_system_test.c`, `test_board_configs.c`, `test_crypto_failclosed.c`,
+`test_driver_recovery.c`, `test_e2e.c`, `test_emulation_simulation.c`, `test_firmware.c`,
+`test_hal_stm32f4.c`, `test_net_integration.c`, `test_net_mock.c`,
+`test_performance_benchmarks.c`, `test_profiles.c`, `test_stress.c`.
+
+Three of those — `test_e2e.c`, `test_net_integration.c`, `test_hal_stm32f4.c` — *are*
+compiled, by hand-written `gcc` lines in `build.yml`, outside CMake entirely. So the
+project has two parallel test systems and neither knows about the other.
+
+`tests/fuzz/` is likewise never added by any `add_subdirectory` (**Verified** — zero
+references in either `CMakeLists.txt` on `master`), so four fuzz targets have never been
+built.
+
+Dark tests are worse than absent ones: they make coverage look larger than it is. Note
+that `test_crypto_failclosed.c` is among them — the test that pins the secure-boot stub
+fail-closed behaviour ADR-011 documents is not run by `ctest`.
+
+## Decision
+
+1. **Adopt Unity** (MIT, **Inferred**) as the C test framework, with **CMock** where
+   driver-level mocking is needed.
+2. **Emit JUnit XML from ctest** so CI can report per-test results rather than a pass/fail
+   process exit.
+3. **Registration is enforced.** A CI check fails when a `tests/**/*.c` file matching the
+   test-file convention is not referenced by a `CMakeLists.txt`. A test that is not run is
+   a defect, and this makes it one the build catches.
+4. **The 13 unregistered files are triaged before this ADR is Accepted**: registered and
+   made to pass, or deleted with the reason recorded. They are not left as they are. The
+   three compiled by `build.yml` move into CMake so there is one test system, not two.
+5. **Migration is incremental.** New tests use Unity; existing files migrate as they are
+   touched. A flag day across ~24 test binaries is not justified.
+
+## Consequences
+
+- Per-board and per-architecture CI matrices (§26) become reportable, because results
+  become data rather than console text.
+- Registering the 13 files may reveal failures. That is the point; ADR-012 needs to know
+  what `test_crypto_failclosed.c` actually reports before it starts, not after.
+- Unity enters `third_party/` under ADR-017 like any other import.
+
+## Open
+
+- Whether the fuzz targets run in CI on every PR or nightly. Nightly is the usual answer,
+  but the devicetree target is cheap enough to run per-PR.
+- Whether `run_all_tests.py` and its pytest suites fold into ctest or stay separate.

--- a/docs/adr/ADR-019-ebuild-pinned-dependencies.md
+++ b/docs/adr/ADR-019-ebuild-pinned-dependencies.md
@@ -1,0 +1,61 @@
+---
+adr: 19
+title: ebuild consumes eos and eBoot as pinned dependencies
+status: Proposed
+date: 2026-08-28
+deciders: Architecture Council (§33), Build & Tooling maintainers, EoS maintainers
+source: EmbeddedOS Platform Architecture & Ecosystem Design Document v0.9, §6, §9, §22
+---
+
+# ADR-019 — ebuild consumes eos and eBoot as pinned dependencies
+
+## Context
+
+§9 makes `ebuild` the developer control plane, and §6 makes it a developer tool rather
+than a runtime dependency. Both are the right calls. Neither describes what the repository
+currently contains.
+
+**Verified — measured on `origin/master` of both repositories, 28 Aug 2026, by comparing
+git blob hashes:**
+
+| Copy | Files | Still identical | **Already drifted** |
+|---|---|---|---|
+| `ebuild/core/eos/` ← `eos` | 350 | 306 | **44** |
+| `ebuild/core/eboot/` ← `eBoot` | 167 | 120 | **46** |
+
+Across the wider organisation, **322 C/H files are byte-identical between two or more
+repositories** (**Verified**, same method).
+
+`ebuild` carries a full snapshot of two other repositories, and ninety of those files have
+already diverged from their sources. Every fix merged into `eos` — including the 21 open
+pull requests — silently misses the copy. A security fix landed in one is absent from the
+other, and nothing anywhere reports that.
+
+## Decision
+
+1. **`ebuild/core/eos/` and `ebuild/core/eboot/` are replaced by pinned dependencies** on
+   the `eos` and `eBoot` repositories, using the mechanism ADR-017 settles.
+2. **Until that lands, a drift guard is mandatory.** `ebuild` CI fails when
+   `core/eos/**` or `core/eboot/**` differs from the pinned upstream revision. Visible
+   drift is not a fix, but invisible drift is the actual danger.
+3. **The 90 drifted files are reconciled explicitly**, file by file. Each divergence is
+   either a fix that belongs upstream — sent there as a PR — or an unintended edit, which
+   is reverted. Neither outcome is "leave it".
+4. **The compatibility matrix §26 requires is the pin.** `ebuild` declares which `eos` and
+   `eBoot` revisions it is tested against, and that declaration is the matrix rather than a
+   separate document that drifts on its own.
+
+## Consequences
+
+- `ebuild` stops being able to silently patch the OS underneath a user. That is the
+  intended loss.
+- A change spanning tool and OS becomes two PRs and a pin bump. Slower per change, and the
+  only way the dependency direction in §6 is actually enforced rather than described.
+- The other 322-file duplication cluster across the organisation needs the same treatment.
+  It is out of scope here and needs its own record.
+
+## Open
+
+- Submodule, `FetchContent`, or a west-style manifest. A manifest scales better to the
+  ~19-repository organisation and is the likely answer, but it is a larger change.
+- Whether the drift guard blocks merges or only warns, during the reconciliation window.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,30 @@
+# Architecture Decision Records
+
+One file per decision. A record is never edited after it reaches **Accepted** — it is
+superseded by a later record that names it.
+
+| Status | Meaning |
+|---|---|
+| Proposed | Written, not yet ratified by the maintainers named in `deciders`. |
+| Accepted | Ratified. Binding on new code. |
+| Superseded | Replaced; the replacing ADR is named in the header. |
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| 012 | [Cryptographic provider selection](ADR-012-cryptographic-provider-selection.md) | Proposed |
+| 013 | [Flattened device tree parsing via libfdt](ADR-013-devicetree-via-libfdt.md) | Proposed |
+| 014 | [TCP/IP via lwIP](ADR-014-tcpip-via-lwip.md) | Proposed |
+| 015 | [Vendor HAL adapter policy](ADR-015-vendor-hal-adapter-policy.md) | Proposed |
+| 016 | [Board and feature description via devicetree and Kconfig](ADR-016-devicetree-and-kconfig.md) | Proposed |
+| 017 | [Third-party dependency, vendoring and SBOM policy](ADR-017-third-party-and-sbom-policy.md) | Proposed |
+| 018 | [Test framework and machine-readable CI results](ADR-018-test-framework.md) | Proposed |
+| 019 | [ebuild consumes eos and eBoot as pinned dependencies](ADR-019-ebuild-pinned-dependencies.md) | Proposed |
+
+## Note on numbering
+
+ADR-001 through ADR-011 exist on the `reconcile/tier-1` branch and have not yet been
+pushed to `master`. This set starts at 012 so that those numbers are not reused. ADR-012
+closes a question ADR-011 left explicitly Open; merging this set without ADR-001–011 will
+leave those cross-references dangling until that branch lands.


### PR DESCRIPTION
§4 of the architecture document says: *"Do not invent new cryptographic primitives; integrate reviewed cryptographic implementations."*

The tree does not comply, and it does not comply anywhere else either — a scan of `eos` for vendored dependencies returns **nothing at all**. Crypto, the FDT parser, the network stack and the vendor HALs are all first-party.

These eight records decide what gets adopted, and under what rules.

| ADR | Decision |
|---|---|
| **012** | **Cryptographic provider selection** — closes the question ADR-011 left explicitly Open. Mbed TLS via the PSA Crypto API; verify-only subset in eBoot; footprint measurement is a *blocking* prerequisite. |
| **013** | FDT parsing via **libfdt**, keeping PR #50’s test corpus and its `tests/fuzz` wiring. |
| **014** | TCP/IP via **lwIP**, and correcting eNet’s §25 status to `Planned`. |
| **015** | **Vendor HAL adapter policy** — CMSIS-Core plus vendor SDKs beneath an unchanged EoS HAL API. This is the multi-vendor lever. |
| **016** | **Devicetree + Kconfig** for board and feature description. |
| **017** | **Third-party, vendoring and SBOM policy.** Prerequisite for all the above; nothing imports until this is Accepted. |
| **018** | **Unity/CMock** and machine-readable CI results. |
| **019** | **ebuild consumes eos and eBoot as pinned dependencies**, not copies. |

### Measured evidence behind ADR-019

Comparing git blob hashes on `origin/master` of both repositories, 2026-08-28:

| Copy | Files | Still identical | **Already drifted** |
|---|---|---|---|
| `ebuild/core/eos/` ← eos | 350 | 306 | **44** |
| `ebuild/core/eboot/` ← eBoot | 167 | 120 | **46** |

322 C/H files are byte-identical across two or more repositories in the organisation. Every fix merged here silently misses the copy.

### Note on numbering

`docs/adr/` does not yet exist on `master` — ADR-001..011 are on the unpushed `reconcile/tier-1` branch. This set starts at 012 so those numbers are not reused; cross-references to them dangle until that branch lands. This is called out in `docs/adr/README.md`.

All eight are **Proposed**, not Accepted. Each names what it costs and what is still Unknown. Docs only — no build input is touched.