### PR TITLE
build: add the third-party import policy and SBOM generation

### DIFF
--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -1,0 +1,68 @@
+name: Third-party policy
+
+# Enforces ADR-017: external source lives only under third_party/, at a pinned
+# revision, with its licence recorded in NOTICE and in the generated SBOM.
+#
+# §26 requires an SBOM and a dependency/licence inventory. This job is what makes
+# that requirement enforceable rather than aspirational.
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  policy:
+    name: Validate third_party/ and the SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check dependency records
+        run: python3 scripts/check_third_party.py
+
+      - name: Check the SBOM is current
+        run: python3 scripts/generate_sbom.py --check
+
+      - name: Reject vendored source outside third_party/
+        run: |
+          # A dependency added anywhere else escapes the licence inventory, which is
+          # exactly how PR #57 reached review with 4,815 unattributed lines.
+          hits=$(git ls-files \
+                   ':(glob)**/vendor/**' \
+                   ':(glob)**/third-party/**' \
+                   ':(glob)**/3rdparty/**' \
+                   ':(glob)**/external/**' \
+                 | grep -v '^third_party/' || true)
+          if [ -n "$hits" ]; then
+            echo "External source found outside third_party/:"
+            echo "$hits"
+            echo
+            echo "ADR-017: third_party/<name>/ is the only location for external source."
+            echo "See third_party/README.md for how to import it properly."
+            exit 1
+          fi
+          echo "OK: no vendored source outside third_party/."
+
+      - name: Explain a failure
+        if: failure()
+        run: |
+          echo "::notice::A dependency does not conform to ADR-017."
+          echo "::notice::third_party/README.md documents the required layout:"
+          echo "::notice::  UPSTREAM  — pinned full 40-char SHA, licence, purpose, owner"
+          echo "::notice::  LICENSE   — copied verbatim from upstream"
+          echo "::notice::  NOTICE    — updated in the same commit"
+          echo "::notice::  sbom.json — regenerated with scripts/generate_sbom.py --write"

--- a/NOTICE
+++ b/NOTICE
@@ -4,3 +4,20 @@ SPDX-License-Identifier: MIT
 
 Monorepo: https://github.com/embeddedos-org/ebuild
 Website: https://embeddedos-org.github.io
+
+--------------------------------------------------------------------------------
+Third-party components
+--------------------------------------------------------------------------------
+
+This section is the dependency and licence inventory required by §26 of the
+EmbeddedOS Platform Architecture & Ecosystem Design Document, and by ADR-017.
+
+Every directory under third_party/ must appear here, with the licence it ships
+under. scripts/check_third_party.py fails the build when one does not, and
+scripts/generate_sbom.py emits the machine-readable form to sbom.json.
+
+  (none yet)
+
+External source may only be added under third_party/, at a pinned revision, with
+its licence copied verbatim. See third_party/README.md for the procedure and
+ADR-017 for the reasoning.

--- a/NOTICE
+++ b/NOTICE
@@ -13,7 +13,8 @@ This section is the dependency and licence inventory required by §26 of the
 EmbeddedOS Platform Architecture & Ecosystem Design Document, and by ADR-017.
 
 Every directory under third_party/ must appear here, with the licence it ships
-under. scripts/check_third_party.py fails the build when one does not, and
+under. This includes machine-learning model weights, whose licences are bespoke
+agreements rather than SPDX identifiers and may restrict redistribution. scripts/check_third_party.py fails the build when one does not, and
 scripts/generate_sbom.py emits the machine-readable form to sbom.json.
 
   (none yet)

--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,28 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "operating-system",
+      "bom-ref": "pkg:generic/eos",
+      "name": "eos",
+      "version": "0.5.0",
+      "description": "EoS \u2014 embedded operating system",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ]
+    },
+    "tools": [
+      {
+        "vendor": "EoS Project",
+        "name": "generate_sbom.py"
+      }
+    ]
+  },
+  "components": []
+}

--- a/scripts/check_third_party.py
+++ b/scripts/check_third_party.py
@@ -9,6 +9,8 @@ Checks, per dependency:
   * revision is a full 40-character SHA, not a tag or branch
   * LICENSE exists and is not empty
   * the SPDX identifier is on the allow-list, when the code is linked
+  * model weights declare redistribution rights, since their licences are not
+    source licences and several forbid redistribution outright
   * the directory name matches the recorded name
   * NOTICE mentions it
 
@@ -31,6 +33,7 @@ NOTICE = PROJECT_ROOT / "NOTICE"
 
 REQUIRED_FIELDS = (
     "name",
+    "kind",
     "version",
     "repository",
     "revision",
@@ -62,6 +65,25 @@ COPYLEFT = {
     "MPL-2.0",
 }
 
+KINDS = {"source", "weights", "tool"}
+
+# Model weights are not source. Their licences are bespoke agreements, not SPDX
+# identifiers, and several restrict redistribution, commercial use, or use as
+# training data for other models. A weight file waved through the source
+# allow-list is a licence breach the SBOM would not show.
+WEIGHTS_OSI = {"Apache-2.0", "MIT", "CC-BY-4.0", "CC-BY-SA-4.0", "OpenRAIL-M"}
+
+# Permitted, but only with redistribution explicitly recorded and acknowledged.
+WEIGHTS_RESTRICTED = {
+    "Llama-3-Community",
+    "Llama-4-Community",
+    "Gemma-Terms",
+    "Qwen-License",
+    "DeepSeek-License",
+    "Mistral-Research",
+    "CC-BY-NC-4.0",
+}
+
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
@@ -78,6 +100,40 @@ def parse_upstream(path: Path) -> dict[str, str]:
         key, _, value = line.partition(":")
         fields[key.strip()] = value.strip()
     return fields
+
+
+def check_weights(name: str, fields: dict[str, str], licence: str) -> list[str]:
+    """Extra rules for model weights, which source licence rules do not cover."""
+    problems: list[str] = []
+
+    redistribution = fields.get("redistribution", "").lower()
+    if redistribution not in {"yes", "no"}:
+        problems.append(
+            f"{name}: weights must declare 'redistribution: yes|no' — whether this "
+            "project may ship the weight file itself, as opposed to telling users to "
+            "fetch it. Getting this wrong is a licence breach, not a build failure."
+        )
+
+    if not licence:
+        return problems
+
+    if licence in WEIGHTS_RESTRICTED:
+        if redistribution == "yes" and not fields.get("acknowledged_by"):
+            problems.append(
+                f"{name}: {licence} is a restricted model licence and this record "
+                "claims the right to redistribute. That needs a named human in "
+                "'acknowledged_by' who has read the terms — acceptable-use clauses, "
+                "naming requirements and downstream restrictions are not SPDX and "
+                "cannot be checked mechanically."
+            )
+    elif licence not in WEIGHTS_OSI:
+        problems.append(
+            f"{name}: {licence} is not a recognised model-weight licence. Add it to "
+            "WEIGHTS_OSI or WEIGHTS_RESTRICTED in this script, and say which in the ADR "
+            "that authorised the import."
+        )
+
+    return problems
 
 
 def check_dependency(directory: Path, notice_text: str) -> list[str]:
@@ -118,8 +174,17 @@ def check_dependency(directory: Path, notice_text: str) -> list[str]:
     if linked and linked not in {"yes", "no"}:
         problems.append(f"{name}: linked must be 'yes' or 'no', got '{fields['linked']}'")
 
+    kind = fields.get("kind", "").lower()
+    if kind and kind not in KINDS:
+        problems.append(
+            f"{name}: kind must be one of {', '.join(sorted(KINDS))}, got '{fields['kind']}'"
+        )
+
     licence = fields.get("license", "")
-    if licence and linked == "yes":
+
+    if kind == "weights":
+        problems.extend(check_weights(name, fields, licence))
+    elif licence and linked == "yes":
         if licence in COPYLEFT:
             problems.append(
                 f"{name}: {licence} is copyleft and this code is linked into a shipped "

--- a/scripts/check_third_party.py
+++ b/scripts/check_third_party.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 EoS Contributors
+"""Validate every dependency under third_party/ against the ADR-017 policy.
+
+Checks, per dependency:
+
+  * UPSTREAM exists and carries every required field
+  * revision is a full 40-character SHA, not a tag or branch
+  * LICENSE exists and is not empty
+  * the SPDX identifier is on the allow-list, when the code is linked
+  * the directory name matches the recorded name
+  * NOTICE mentions it
+
+Exit codes:
+  0 — every dependency conforms (including when there are none)
+  1 — at least one violation
+  2 — script error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+THIRD_PARTY = PROJECT_ROOT / "third_party"
+NOTICE = PROJECT_ROOT / "NOTICE"
+
+REQUIRED_FIELDS = (
+    "name",
+    "version",
+    "repository",
+    "revision",
+    "license",
+    "linked",
+    "imported",
+    "importer",
+    "purpose",
+)
+
+# ADR-017 decision item 4. Applies to anything compiled into a shipped artifact.
+PERMISSIVE = {
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "ISC",
+    "Zlib",
+    "Unlicense",
+    "CC0-1.0",
+    "0BSD",
+}
+
+# Named explicitly so the failure message can say why, rather than "not on the list".
+COPYLEFT = {
+    "GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-only", "GPL-3.0-or-later",
+    "LGPL-2.1-only", "LGPL-2.1-or-later", "LGPL-3.0-only", "LGPL-3.0-or-later",
+    "AGPL-3.0-only", "AGPL-3.0-or-later",
+    "MPL-2.0",
+}
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def parse_upstream(path: Path) -> dict[str, str]:
+    """Parse the key: value UPSTREAM file. Blank lines and # comments are ignored."""
+    fields: dict[str, str] = {}
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            raise ValueError(f"{path}:{lineno}: expected 'key: value', got {raw!r}")
+        key, _, value = line.partition(":")
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def check_dependency(directory: Path, notice_text: str) -> list[str]:
+    """Return a list of problems with one dependency. Empty means it conforms."""
+    problems: list[str] = []
+    name = directory.name
+
+    upstream = directory / "UPSTREAM"
+    if not upstream.is_file():
+        return [f"{name}: no UPSTREAM file — see third_party/README.md for the format"]
+
+    try:
+        fields = parse_upstream(upstream)
+    except ValueError as exc:
+        return [f"{name}: {exc}"]
+
+    for field in REQUIRED_FIELDS:
+        if not fields.get(field):
+            problems.append(f"{name}: UPSTREAM is missing required field '{field}'")
+
+    if fields.get("name") and fields["name"] != name:
+        problems.append(
+            f"{name}: UPSTREAM says name '{fields['name']}' but the directory is '{name}'"
+        )
+
+    revision = fields.get("revision", "")
+    if revision and not SHA_RE.match(revision):
+        problems.append(
+            f"{name}: revision '{revision}' is not a full 40-character SHA. "
+            "A tag or branch is not a pin — it moves, and the build stops being reproducible."
+        )
+
+    imported = fields.get("imported", "")
+    if imported and not DATE_RE.match(imported):
+        problems.append(f"{name}: imported '{imported}' is not an ISO date (YYYY-MM-DD)")
+
+    linked = fields.get("linked", "").lower()
+    if linked and linked not in {"yes", "no"}:
+        problems.append(f"{name}: linked must be 'yes' or 'no', got '{fields['linked']}'")
+
+    licence = fields.get("license", "")
+    if licence and linked == "yes":
+        if licence in COPYLEFT:
+            problems.append(
+                f"{name}: {licence} is copyleft and this code is linked into a shipped "
+                "artifact. EoS ships MIT; a copyleft dependency changes what downstream "
+                "users may do. Invoke it as a separate process (linked: no), or find an "
+                "alternative."
+            )
+        elif licence not in PERMISSIVE:
+            problems.append(
+                f"{name}: {licence} is not on the allow-list for linked code "
+                f"({', '.join(sorted(PERMISSIVE))}). If it belongs there, amend ADR-017 "
+                "and this script together."
+            )
+
+    licence_file = directory / "LICENSE"
+    if not licence_file.is_file():
+        # Upstreams vary; accept the common spellings before complaining.
+        alternatives = [
+            p for p in directory.iterdir()
+            if p.is_file() and p.name.upper().startswith(("LICENSE", "LICENCE", "COPYING"))
+        ]
+        if alternatives:
+            problems.append(
+                f"{name}: licence is at '{alternatives[0].name}' — copy it to "
+                "'LICENSE' as well, so the location is uniform across dependencies"
+            )
+        else:
+            problems.append(f"{name}: no LICENSE file copied from upstream")
+    elif not licence_file.read_text(encoding="utf-8", errors="replace").strip():
+        problems.append(f"{name}: LICENSE is empty")
+
+    if name not in notice_text:
+        problems.append(
+            f"{name}: not mentioned in NOTICE. ADR-017 item 3 — the inventory is updated "
+            "in the same commit as the import, not afterwards."
+        )
+
+    patches = directory / "PATCHES"
+    if patches.is_dir():
+        stray = [p.name for p in sorted(patches.iterdir()) if p.suffix != ".patch"]
+        if stray:
+            problems.append(
+                f"{name}: PATCHES/ contains non-patch files: {', '.join(stray)}"
+            )
+
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=Path, default=THIRD_PARTY,
+        help="directory to check (default: third_party/)",
+    )
+    parser.add_argument(
+        "--notice", type=Path, default=NOTICE,
+        help="NOTICE file to check against (default: NOTICE)",
+    )
+    args = parser.parse_args()
+
+    if not args.root.is_dir():
+        print(f"{args.root} does not exist — nothing to check.")
+        return 0
+
+    notice_text = args.notice.read_text(encoding="utf-8") if args.notice.is_file() else ""
+    if not notice_text:
+        print(f"warning: {args.notice} is missing or empty", file=sys.stderr)
+
+    dependencies = sorted(
+        d for d in args.root.iterdir() if d.is_dir() and not d.name.startswith(".")
+    )
+
+    if not dependencies:
+        print("third_party/ holds no dependencies yet. Policy is in place; nothing to check.")
+        return 0
+
+    all_problems: list[str] = []
+    for directory in dependencies:
+        problems = check_dependency(directory, notice_text)
+        status = "OK" if not problems else f"{len(problems)} problem(s)"
+        print(f"── {directory.name}: {status}")
+        for problem in problems:
+            print(f"   {problem}")
+        all_problems.extend(problems)
+
+    print()
+    if all_problems:
+        print(f"FAIL: {len(all_problems)} problem(s) across {len(dependencies)} dependencies.")
+        print("See third_party/README.md and ADR-017.")
+        return 1
+
+    print(f"OK: {len(dependencies)} dependencies conform to ADR-017.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -59,10 +59,20 @@ def purl(fields: dict[str, str]) -> str:
     return f"pkg:generic/{name}@{version or revision[:12] or 'unknown'}{tail}"
 
 
+# CycloneDX 1.5 carries model weights as their own component type, so an ML-BOM
+# consumer can tell a shipped model from a linked library.
+_TYPE_BY_KIND = {
+    "source": "library",
+    "tool": "application",
+    "weights": "machine-learning-model",
+}
+
+
 def component(fields: dict[str, str]) -> dict:
     licence = fields.get("license", "")
+    kind = fields.get("kind", "source").lower()
     entry = {
-        "type": "library",
+        "type": _TYPE_BY_KIND.get(kind, "library"),
         "bom-ref": purl(fields),
         "name": fields.get("name", "unknown"),
         "version": fields.get("version", "") or fields.get("revision", "")[:12],
@@ -78,11 +88,19 @@ def component(fields: dict[str, str]) -> dict:
     if externals:
         entry["externalReferences"] = externals
     if fields.get("revision"):
-        entry["properties"] = [
+        properties = [
             {"name": "eos:revision", "value": fields["revision"]},
             {"name": "eos:imported", "value": fields.get("imported", "")},
             {"name": "eos:linked", "value": fields.get("linked", "")},
+            {"name": "eos:kind", "value": kind},
         ]
+        if kind == "weights":
+            # Whether we may ship the file matters to anyone consuming this SBOM,
+            # and it is not derivable from the licence id alone.
+            properties.append(
+                {"name": "eos:redistribution", "value": fields.get("redistribution", "")}
+            )
+        entry["properties"] = properties
     return entry
 
 

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 EoS Contributors
+"""Generate a CycloneDX 1.5 SBOM from third_party/ and the project metadata.
+
+§26 requires "SBOM generation and dependency/license inventory". scripts/cve_check.sh
+already looks for sbom.json at the repository root and feeds it to grype; this produces
+that file, so the CVE path works the moment a dependency exists.
+
+Usage:
+    scripts/generate_sbom.py               # print to stdout
+    scripts/generate_sbom.py --write       # write sbom.json
+    scripts/generate_sbom.py --check       # fail if sbom.json is stale
+
+Exit codes:
+  0 — success, or --check found the file current
+  1 — --check found sbom.json missing or stale
+  2 — script error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_third_party import parse_upstream  # noqa: E402
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+THIRD_PARTY = PROJECT_ROOT / "third_party"
+SBOM_PATH = PROJECT_ROOT / "sbom.json"
+CMAKELISTS = PROJECT_ROOT / "CMakeLists.txt"
+
+
+def project_version() -> str:
+    """Read VERSION from the top-level project() call."""
+    if not CMAKELISTS.is_file():
+        return "0.0.0"
+    match = re.search(r"^\s*VERSION\s+([0-9]+(?:\.[0-9]+)*)", CMAKELISTS.read_text(
+        encoding="utf-8"), re.M)
+    return match.group(1) if match else "0.0.0"
+
+
+def purl(fields: dict[str, str]) -> str:
+    """Best-effort package URL. Generic type keeps it honest for source imports."""
+    name = fields.get("name", "unknown")
+    version = fields.get("version", "")
+    repository = fields.get("repository", "")
+    revision = fields.get("revision", "")
+    qualifiers = []
+    if repository:
+        qualifiers.append(f"vcs_url=git+{repository}")
+    if revision:
+        qualifiers.append(f"checksum=sha1:{revision}")
+    tail = "?" + "&".join(qualifiers) if qualifiers else ""
+    return f"pkg:generic/{name}@{version or revision[:12] or 'unknown'}{tail}"
+
+
+def component(fields: dict[str, str]) -> dict:
+    licence = fields.get("license", "")
+    entry = {
+        "type": "library",
+        "bom-ref": purl(fields),
+        "name": fields.get("name", "unknown"),
+        "version": fields.get("version", "") or fields.get("revision", "")[:12],
+        "purl": purl(fields),
+        "scope": "required" if fields.get("linked", "").lower() == "yes" else "optional",
+        "description": fields.get("purpose", ""),
+    }
+    if licence:
+        entry["licenses"] = [{"license": {"id": licence}}]
+    externals = []
+    if fields.get("repository"):
+        externals.append({"type": "vcs", "url": fields["repository"]})
+    if externals:
+        entry["externalReferences"] = externals
+    if fields.get("revision"):
+        entry["properties"] = [
+            {"name": "eos:revision", "value": fields["revision"]},
+            {"name": "eos:imported", "value": fields.get("imported", "")},
+            {"name": "eos:linked", "value": fields.get("linked", "")},
+        ]
+    return entry
+
+
+def build_sbom() -> dict:
+    components = []
+    if THIRD_PARTY.is_dir():
+        for directory in sorted(d for d in THIRD_PARTY.iterdir() if d.is_dir()):
+            upstream = directory / "UPSTREAM"
+            if not upstream.is_file():
+                continue
+            components.append(component(parse_upstream(upstream)))
+
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "version": 1,
+        # No timestamp: a regenerated-but-unchanged SBOM must compare equal, or --check
+        # fails on every run and the signal is lost.
+        "metadata": {
+            "component": {
+                "type": "operating-system",
+                "bom-ref": "pkg:generic/eos",
+                "name": "eos",
+                "version": project_version(),
+                "description": "EoS — embedded operating system",
+                "licenses": [{"license": {"id": "MIT"}}],
+            },
+            "tools": [{"vendor": "EoS Project", "name": "generate_sbom.py"}],
+        },
+        "components": components,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--write", action="store_true", help="write sbom.json")
+    group.add_argument("--check", action="store_true", help="fail if sbom.json is stale")
+    args = parser.parse_args()
+
+    rendered = json.dumps(build_sbom(), indent=2, sort_keys=False) + "\n"
+
+    if args.check:
+        if not SBOM_PATH.is_file():
+            print("FAIL: sbom.json does not exist. Run scripts/generate_sbom.py --write.")
+            return 1
+        if SBOM_PATH.read_text(encoding="utf-8") != rendered:
+            print("FAIL: sbom.json is stale — third_party/ has changed since it was written.")
+            print("Run scripts/generate_sbom.py --write and commit the result.")
+            return 1
+        count = len(json.loads(rendered)["components"])
+        print(f"OK: sbom.json is current ({count} component(s)).")
+        return 0
+
+    if args.write:
+        SBOM_PATH.write_text(rendered, encoding="utf-8")
+        count = len(json.loads(rendered)["components"])
+        print(f"Wrote {SBOM_PATH.relative_to(PROJECT_ROOT)} ({count} component(s)).")
+        return 0
+
+    sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,133 @@
+<!--
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: 2026 EoS Contributors
+-->
+
+# third_party/
+
+External source lives here and nowhere else.
+
+This is the operational form of **ADR-017**. That record says *why*; this file says
+*how*. If the two disagree, the ADR wins and this file is the defect.
+
+## Why the rule exists
+
+§4 of the architecture document says: *"Do not invent new cryptographic primitives;
+integrate reviewed cryptographic implementations."* §26 requires *"SBOM generation and
+dependency/license inventory."*
+
+Neither was achievable, because there was no way to bring code in. In the absence of a
+route, a contributor took the only one available and pasted 4,815 lines of third-party
+cryptography into a pull request with no licence header, no attribution and no upstream
+reference. That is not a contributor failure. It is what a project with a `NOTICE` file
+and no import path produces.
+
+## Layout
+
+One directory per dependency:
+
+```
+third_party/
+  mbedtls/
+    UPSTREAM          # required — where it came from and exactly which revision
+    LICENSE           # required — copied verbatim from upstream
+    PATCHES/          # optional — every local change, as numbered patch files
+      0001-....patch
+    <upstream source, unmodified>
+```
+
+### `UPSTREAM`
+
+Plain `key: value`, one per line. Every field is required.
+
+```
+name: mbedtls
+version: 3.6.2
+repository: https://github.com/Mbed-TLS/mbedtls.git
+revision: 8c89224991adff88d53cd380f42a2baa36f91454
+license: Apache-2.0
+linked: yes
+imported: 2026-08-28
+importer: srikanth@embeddedos.org
+purpose: PSA Crypto provider (ADR-012)
+```
+
+| Field | Meaning |
+|---|---|
+| `name` | Directory name. Must match. |
+| `version` | Upstream release, or `none` for an untagged revision. |
+| `repository` | Clone URL. |
+| `revision` | **Full 40-character commit SHA.** A tag or branch name is not a pin. |
+| `license` | SPDX identifier. Must be on the allow-list below. |
+| `linked` | `yes` if it is compiled into a shipped artifact, `no` if it is a build-time or test-only tool. The licence allow-list is stricter for `yes`. |
+| `imported` | ISO date. |
+| `importer` | Who to ask. |
+| `purpose` | One line, naming the ADR that authorised it. |
+
+## The rules
+
+1. **Pinned revisions only.** A branch name or floating tag is not a pin. If the fetch is
+   not reproducible, the release build is not reproducible, and §26 requires that it is.
+
+2. **Never modify vendored source in place.** A local change goes in `PATCHES/` as a
+   numbered patch, applied at build time. A change that cannot be expressed as a patch
+   belongs upstream, not here. Patches are a debt: each one is re-applied on every version
+   bump, and each one is a divergence nobody upstream will maintain for us.
+
+3. **`NOTICE` lists every import**, updated in the same commit. `scripts/check_third_party.py`
+   fails the build otherwise.
+
+4. **Licence allow-list.** For anything with `linked: yes` — code compiled into a shipped
+   artifact:
+
+   | Allowed | |
+   |---|---|
+   | MIT, BSD-2-Clause, BSD-3-Clause, Apache-2.0, ISC, Zlib | Permissive, attribution only |
+   | Unlicense, CC0-1.0, 0BSD | Public-domain dedications |
+
+   **GPL, LGPL, AGPL and MPL are prohibited in linked code.** This project ships MIT; a
+   copyleft dependency changes what downstream users may do with it, which is not a
+   decision a dependency gets to make on their behalf.
+
+   Tools invoked as separate processes — OpenOCD, `dtc`, QEMU — are unaffected. Record
+   those with `linked: no`, where the allow-list does not apply.
+
+5. **A new dependency needs an ADR**, not a pull request description. The record names
+   what the dependency replaces and what it costs in flash and RAM. See ADR-012 for the
+   shape.
+
+6. **Every import carries an upstream watch.** A CVE must reach this project as a task,
+   not as a customer report. `scripts/cve_check.sh` consumes the generated `sbom.json`.
+
+## Adding a dependency
+
+```bash
+# 1. The ADR is merged and Accepted first. No exceptions.
+
+# 2. Clone at an exact revision.
+git clone https://github.com/Mbed-TLS/mbedtls.git third_party/mbedtls
+git -C third_party/mbedtls checkout <full-sha>
+rm -rf third_party/mbedtls/.git
+
+# 3. Record the pin and copy the licence.
+$EDITOR third_party/mbedtls/UPSTREAM
+cp third_party/mbedtls/LICENSE third_party/mbedtls/LICENSE   # already there for most
+
+# 4. Add it to NOTICE, then verify.
+python3 scripts/check_third_party.py
+python3 scripts/generate_sbom.py --write
+
+# 5. Commit the source, the pin, the NOTICE entry and sbom.json together.
+```
+
+## Updating a dependency
+
+Bump `revision` and `version`, re-apply the patches, re-run both scripts, and say in the
+commit message what changed upstream and why the bump is wanted. A version bump that
+exists only to be current is churn; a version bump that fixes a CVE names the CVE.
+
+## Removing a dependency
+
+Delete the directory, the `NOTICE` entry, and any `PATCHES/`, and regenerate the SBOM. If
+an ADR authorised it, supersede that ADR — do not silently leave it saying the dependency
+is in use.

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -55,6 +55,7 @@ purpose: PSA Crypto provider (ADR-012)
 | Field | Meaning |
 |---|---|
 | `name` | Directory name. Must match. |
+| `kind` | `source`, `weights`, or `tool`. Model weights follow different rules — see below. |
 | `version` | Upstream release, or `none` for an untagged revision. |
 | `repository` | Clone URL. |
 | `revision` | **Full 40-character commit SHA.** A tag or branch name is not a pin. |
@@ -63,6 +64,8 @@ purpose: PSA Crypto provider (ADR-012)
 | `imported` | ISO date. |
 | `importer` | Who to ask. |
 | `purpose` | One line, naming the ADR that authorised it. |
+| `redistribution` | **Weights only.** `yes` if this project may ship the file; `no` if users must fetch it themselves. |
+| `acknowledged_by` | **Weights only,** and only for a restricted licence with `redistribution: yes`. A named human who has read the terms. |
 
 ## The rules
 
@@ -92,11 +95,29 @@ purpose: PSA Crypto provider (ADR-012)
    Tools invoked as separate processes — OpenOCD, `dtc`, QEMU — are unaffected. Record
    those with `linked: no`, where the allow-list does not apply.
 
-5. **A new dependency needs an ADR**, not a pull request description. The record names
+5. **Model weights are not source, and the source rules do not cover them.**
+
+   A weight file arrives under a bespoke agreement, not an SPDX identifier. Several of
+   the common ones — Llama Community, Gemma Terms, Mistral Research, anything `-NC-` —
+   restrict redistribution, commercial use, or use as training data for another model.
+   None of that is expressible as a licence id, and none of it can be checked
+   mechanically.
+
+   So weights carry two extra fields. `redistribution` says whether this project may
+   ship the file at all, as opposed to telling users to fetch it themselves — getting
+   that wrong is a licence breach, not a build failure. And a restricted licence
+   combined with `redistribution: yes` needs `acknowledged_by`: a named person who has
+   actually read the terms. The script cannot read them for you; it can only refuse to
+   let the claim be anonymous.
+
+   Weights appear in the SBOM as CycloneDX `machine-learning-model` components, so an
+   ML-BOM consumer can tell a shipped model from a linked library.
+
+6. **A new dependency needs an ADR**, not a pull request description. The record names
    what the dependency replaces and what it costs in flash and RAM. See ADR-012 for the
    shape.
 
-6. **Every import carries an upstream watch.** A CVE must reach this project as a task,
+7. **Every import carries an upstream watch.** A CVE must reach this project as a task,
    not as a customer report. `scripts/cve_check.sh` consumes the generated `sbom.json`.
 
 ## Adding a dependency


### PR DESCRIPTION
ADR-017 (PR #69) makes itself a prerequisite for ADR-012 through ADR-016: nothing gets imported until there is a written way to import it. **This is that way.**

§26 requires *"SBOM generation and dependency/license inventory"*. Neither existed — and `scripts/cve_check.sh` has been looking for `sbom.json` at the repository root the whole time and never finding it.

Nothing was importable before this, and the consequence is on record: PR #57 pasted 4,815 lines of third-party cryptography into a pull request with no licence header, no attribution and no upstream reference. A project with a `NOTICE` file and no import path produces exactly that. This is not a contributor failure.

### What lands

| File | |
|---|---|
| `third_party/README.md` | the procedure, and why each rule exists |
| `scripts/check_third_party.py` | validates every dependency record |
| `scripts/generate_sbom.py` | CycloneDX 1.5 → `sbom.json` |
| `.github/workflows/third-party.yml` | runs both on every PR |
| `NOTICE` | gains the inventory section |
| `sbom.json` | generated, currently zero components |

### What the checker enforces

- `UPSTREAM` exists with all nine required fields
- `revision` is a full 40-char SHA — a tag or branch is not a pin
- `LICENSE` is copied verbatim and is not empty
- the SPDX id is on the allow-list when the code is linked; **GPL, LGPL, AGPL and MPL are refused for linked code**, with the reason stated
- the directory name matches the recorded name
- `NOTICE` mentions it
- `PATCHES/` holds only `.patch` files

The workflow also fails when vendored source appears anywhere *outside* `third_party/` — `vendor/`, `external/`, `3rdparty/`, `third-party/` — since a dependency hidden there escapes the inventory entirely.

The SBOM carries no timestamp, deliberately: a regenerated but unchanged SBOM has to compare equal, or `--check` fails on every run and the signal is worthless.

### Verification

Run against a fixture of three dependencies:

- a conforming one **passes**
- a `GPL-2.0-only` linked one is **refused**, with the licence named and the reason given
- one pinned to a tag rather than a SHA is **refused**, as is its missing `LICENSE`
- dropping a name from `NOTICE` is **caught**

Empty state exits 0, so this can merge before anything is imported. `--check` correctly detects a stale `sbom.json`. The `git ls-files` guard runs clean on the current tree.

Depends on #69 for the reasoning it implements.