### PR TITLE
fix(heap): validate the block header in eos_realloc(), not just eos_free()

### DIFF
--- a/kernel/src/mem/heap.c
+++ b/kernel/src/mem/heap.c
@@ -109,6 +109,45 @@ void *eos_malloc(size_t size)
 }
 
 /**
+ * @brief Recover the block header for a pointer returned by eos_malloc().
+ *
+ * eos_free() range-checked its argument; eos_realloc() did not, so the same
+ * pointer was trusted in one path and validated in the other. Both go through
+ * this now.
+ *
+ * The size check matters as much as the range check: eos_realloc() computed
+ * `block->size - HEADER_SIZE`, so a header whose size field is below
+ * HEADER_SIZE underflowed that to nearly SIZE_MAX and made every growth
+ * request look already satisfied. A single corrupted header byte then turned
+ * into an unbounded overflow in the caller's buffer.
+ *
+ * @return The header, or NULL if @p ptr did not come from this heap or its
+ *         header is not self-consistent.
+ */
+static block_header_t *block_from_ptr(const void *ptr)
+{
+    if (!ptr || !heap_start) return NULL;
+
+    uintptr_t base = (uintptr_t)heap_start;
+    uintptr_t end = base + heap_total;
+    uintptr_t addr = (uintptr_t)ptr;
+
+    if (addr < base + HEADER_SIZE || addr >= end) return NULL;
+
+    uintptr_t header = addr - HEADER_SIZE;
+    if ((header - base) % 8u != 0) return NULL;
+
+    block_header_t *block = (block_header_t *)header;
+
+    /* The block must be big enough to hold its own header and must not claim
+     * to extend past the end of the heap. */
+    if (block->size < MIN_BLOCK_SIZE) return NULL;
+    if (block->size > (size_t)(end - header)) return NULL;
+
+    return block;
+}
+
+/**
  * @brief Coalesce adjacent free blocks starting from the given block.
  */
 static void coalesce(block_header_t *block)
@@ -123,13 +162,8 @@ void eos_free(void *ptr)
 {
     if (!ptr) return;
 
-    block_header_t *block = (block_header_t *)((uint8_t *)ptr - HEADER_SIZE);
-
-    /* Sanity check: pointer should be within heap */
-    if ((uintptr_t)block < (uintptr_t)heap_start ||
-        (uintptr_t)block >= (uintptr_t)heap_start + heap_total) {
-        return;
-    }
+    block_header_t *block = block_from_ptr(ptr);
+    if (!block) return;       /* Not ours, or the header is not believable */
 
     if (block->free) return;  /* Double-free protection */
 
@@ -159,7 +193,9 @@ void *eos_realloc(void *ptr, size_t new_size)
     if (!ptr) return eos_malloc(new_size);
     if (new_size == 0) { eos_free(ptr); return NULL; }
 
-    block_header_t *block = (block_header_t *)((uint8_t *)ptr - HEADER_SIZE);
+    block_header_t *block = block_from_ptr(ptr);
+    if (!block) return NULL;  /* Not ours, or the header is not believable */
+
     size_t current_usable = block->size - HEADER_SIZE;
 
     if (new_size <= current_usable) return ptr;  /* Fits in current block */

--- a/tests/test_heap.c
+++ b/tests/test_heap.c
@@ -5,8 +5,12 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 static uint8_t heap_area[512];
+
+/* Memory that never came from this heap. */
+static uint8_t foreign[128];
 
 int main(void)
 {
@@ -31,6 +35,50 @@ int main(void)
         return 1;
     }
 
-    eos_free(allocation);
+    /* Growing a live allocation must move it and preserve the contents. */
+    memset(allocation, 0x5A, 32);
+    void *grown = eos_realloc(allocation, 96);
+    if (grown == NULL) {
+        fprintf(stderr, "growing realloc failed\n");
+        return 1;
+    }
+    for (int i = 0; i < 32; i++) {
+        if (((uint8_t *)grown)[i] != 0x5A) {
+            fprintf(stderr, "realloc did not preserve the payload\n");
+            return 1;
+        }
+    }
+
+    /* eos_free() range-checks its argument. eos_realloc() did not, so a
+     * pointer that never came from this heap was handed straight back as if
+     * it had been resized. */
+    memset(foreign, 0, sizeof(foreign));
+    if (eos_realloc(foreign + 64, 16) != NULL) {
+        fprintf(stderr, "realloc of a non-heap pointer must be rejected\n");
+        return 1;
+    }
+
+    /* A header claiming a size below HEADER_SIZE underflowed
+     * `block->size - HEADER_SIZE` to nearly SIZE_MAX, so every growth request
+     * looked already satisfied and realloc returned the short buffer. */
+    memset(foreign, 0, sizeof(foreign));
+    ((size_t *)foreign)[0] = 8;
+    if (eos_realloc(foreign + 16, 4096) != NULL) {
+        fprintf(stderr, "realloc must reject a header smaller than itself\n");
+        return 1;
+    }
+
+    /* The same validation must not make eos_free() reject real pointers. */
+    void *second = eos_malloc(48);
+    if (second == NULL) {
+        fprintf(stderr, "allocation after realloc failed\n");
+        return 1;
+    }
+    eos_free(second);
+
+    /* Freeing foreign memory stays a silent no-op, not a crash. */
+    eos_free(foreign + 64);
+
+    eos_free(grown);
     return 0;
 }


### PR DESCRIPTION
## The architectural problem

The kernel allocator has two entry points that take a caller-supplied pointer and derive allocator metadata from it. **One validates that pointer; the other does not.**

`eos_free()` range-checks its argument against the heap. `eos_realloc()` takes the same kind of pointer and trusts whatever it finds:

```c
block_header_t *block = (block_header_t *)((uint8_t *)ptr - HEADER_SIZE);
size_t current_usable = block->size - HEADER_SIZE;

if (new_size <= current_usable) return ptr;   /* "fits in current block" */
```

Two consequences, both **reproduced against the unmodified allocator**:

### 1. A foreign pointer is read out of bounds, then handed back

```
realloc(non-heap ptr, 16) = 0x102a0a020  (input was 0x102a0a020)
  -> returned the foreign pointer unchanged: YES
```

The bytes before `ptr` are read as a block header, and the pointer is returned as if it had been resized. `eos_free()` rejects exactly that pointer.

### 2. A short header underflows the size check into an unbounded overflow

`block->size - HEADER_SIZE` is unsigned. A header whose size field is *below* `HEADER_SIZE` underflows `current_usable` to nearly `SIZE_MAX`, so **every** growth request looks already satisfied:

```
realloc(ptr with size=8 header, 4096) = 0x102a0a010
  -> claimed a 64-byte buffer can hold 4096: YES
```

realloc returns the original short buffer and the caller writes `new_size` bytes into it. That turns a single corrupted header byte — precisely what a prior small overflow leaves behind — into an unbounded overflow, which is the opposite of what an allocator's metadata checks are for.

## The change

Both paths go through one `block_from_ptr()` helper:

- the pointer lies inside the heap,
- its header is 8-byte aligned relative to the heap base,
- the size field is at least `MIN_BLOCK_SIZE`,
- and the block does not claim to extend past the end of the heap.

`eos_free()` uses it too and gains the size checks it did not have. An unrecognised pointer makes `realloc` return `NULL` and `free` a no-op — which is what each already did for the cases it *did* check, so nothing that worked before changes behaviour.

## Verification

| Check | Result |
|---|---|
| `ctest --no-tests=error` | **24/24 pass** |
| `pytest tests/` | 10 passed |

`tests/test_heap.c` gains coverage for both paths plus a grow-and-preserve case (contents survive a move) and a check that the new validation does not reject legitimate pointers. Against the unmodified `heap.c` it fails on `realloc of a non-heap pointer must be rejected`.

## Notes for review

- **#60** also touches `tests/test_heap.c` (it does not touch `kernel/src/mem/heap.c`). If that lands first this needs a trivial rebase in the test file only.
- Independent of **#75**, my other open PR here — different subsystem, both based on `master`.
- Deliberately out of scope: `coalesce()` walks `block->next` without validating it, so a corrupted *next* pointer still escapes the heap. That is a larger change to the block-list invariant and wants its own PR.
