### PR TITLE
ci: stop the simulation workflow failing on repositories that do not exist

### DIFF
--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -55,6 +55,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             gcc-aarch64-linux-gnu \
             binutils-aarch64-linux-gnu \
+            libc6-dev-arm64-cross \
             cmake \
             ninja-build \
             qemu-system-arm \

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -39,12 +39,15 @@ jobs:
           ref: master
           path: ebuild
 
-      - name: Checkout eFab (CAD pipeline)
-        uses: actions/checkout@v4
-        with:
-          repository: embeddedos-org/eFab
-          ref: master
-          path: eFab
+      # embeddedos-org/eFab does not exist -- the checkout 404s and takes this
+      # job, and everything downstream of it, with it. Restore this block and
+      # the CAD step below once the repository is published.
+      # - name: Checkout eFab (CAD pipeline)
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: embeddedos-org/eFab
+      #     ref: master
+      #     path: eFab
 
       - name: Install build dependencies
         run: |
@@ -58,14 +61,19 @@ jobs:
             python3 \
             python3-pytest
 
-      - name: Run eFab CAD pipeline (KiCad → linker script + DTS)
+      # - name: Run eFab CAD pipeline (KiCad → linker script + DTS)
+      #   run: |
+      #     python3 ebuild/tools/cad_pipeline.py \
+      #       eFab/samples/eos_reference_board.kicad_pcb \
+      #       sim_artifacts/
+      #     echo "=== Generated artifacts ==="
+      #     ls -la sim_artifacts/
+      #     cat sim_artifacts/board_manifest.json
+      - name: Prepare artifact directory
         run: |
-          python3 ebuild/tools/cad_pipeline.py \
-            eFab/samples/eos_reference_board.kicad_pcb \
-            sim_artifacts/
-          echo "=== Generated artifacts ==="
-          ls -la sim_artifacts/
-          cat sim_artifacts/board_manifest.json
+          # Normally populated by the eFab CAD pipeline above. Created empty so
+          # the upload step below still has a path to collect.
+          mkdir -p sim_artifacts
 
       - name: Build eBoot (ARM64 qemu_arm64 board)
         run: |
@@ -73,7 +81,7 @@ jobs:
           mkdir -p build_ci
           cmake -B build_ci -S . \
             -DCMAKE_TOOLCHAIN_FILE=toolchains/aarch64-linux-gnu.cmake \
-            -DBOARD=qemu_arm64 \
+            -DEBLDR_BOARD=qemu_arm64 \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build_ci --parallel $(nproc)
           echo "eBoot artifacts:"
@@ -84,7 +92,7 @@ jobs:
           cd eos
           mkdir -p build_ci
           cmake -B build_ci -S . \
-            -DCMAKE_TOOLCHAIN_FILE=cmake/aarch64-linux-gnu.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=toolchains/aarch64-linux-gnu.cmake \
             -DTARGET_ARCH=aarch64 \
             -DTARGET_CPU=cortex-a57 \
             -DCMAKE_BUILD_TYPE=Release
@@ -195,11 +203,13 @@ jobs:
 
   # ── Job 3: Python unit tests for all middleware layers ─────────────────────
   test-middleware:
-    name: "Python unit tests (eAI, eNI, eosllm, eDB, eVera, eBrowser, eIPC)"
+    name: "Python unit tests (eAI, eNI, eosllm, eDB, eBrowser, eIPC)"
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        repo: [eAI, eNI, eosllm, eDB, eVera, eBrowser, eIPC, eOffice, EoStudio, EoSim, eApps]
+        # eVera removed: embeddedos-org/eVera does not exist, so its checkout
+        # 404s. Add it back when the repository is published.
+        repo: [eAI, eNI, eosllm, eDB, eBrowser, eIPC, eOffice, EoStudio, EoSim, eApps]
     steps:
       - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@v4
@@ -211,7 +221,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
+          # No cache: pip. setup-python errors out with "No file ... matched to
+          # [**/requirements.txt or **/pyproject.toml]" when the repository it
+          # is caching for has neither, which is the case for most of the
+          # matrix below. The cache is an optimisation; failing the job over it
+          # is not a trade worth making.
 
       - name: Install dependencies
         run: |
@@ -243,41 +257,48 @@ jobs:
           repository: embeddedos-org/ebuild
           ref: master
 
-      - name: Checkout eFab
-        uses: actions/checkout@v4
-        with:
-          repository: embeddedos-org/eFab
-          ref: master
-          path: eFab
+      # Same missing repository as in build-kernel.
+      # - name: Checkout eFab
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: embeddedos-org/eFab
+      #     ref: master
+      #     path: eFab
 
-      - name: Run CAD pipeline
+      # Every step below reads eFab/samples/eos_reference_board.kicad_pcb, which
+      # cannot be checked out. Restore them together with the checkout above.
+      # - name: Run CAD pipeline
+      #   run: |
+      #     python3 tools/cad_pipeline.py \
+      #       eFab/samples/eos_reference_board.kicad_pcb \
+      #       cad_output/
+      #     echo "=== Validating generated artifacts ==="
+      #     test -f cad_output/eos_generated.ld   && echo "[PASS] Linker script" || exit 1
+      #     test -f cad_output/eos_generated.dts  && echo "[PASS] Device tree" || exit 1
+      #     test -f cad_output/eos_recipe.yaml    && echo "[PASS] ebuild recipe" || exit 1
+      #     test -f cad_output/eos_toolchain.cmake && echo "[PASS] CMake toolchain" || exit 1
+      #     test -f cad_output/board_manifest.json && echo "[PASS] Board manifest" || exit 1
+      #
+      # - name: Validate memory map completeness
+      #   run: |
+      #     python3 - <<'EOF'
+      #     import json
+      #     with open("cad_output/board_manifest.json") as f:
+      #         m = json.load(f)
+      #     regions = {r["name"] for r in m["memory_regions"]}
+      #     required = {"FLASH_NOR", "RAM_LPDDR4", "UART0_PL011", "HEAP_REGION", "OTA_SCRATCH"}
+      #     missing = required - regions
+      #     if missing:
+      #         print(f"[FAIL] Missing memory regions: {missing}")
+      #         exit(1)
+      #     print(f"[PASS] All required memory regions present: {required}")
+      #     print(f"[PASS] Total regions: {len(regions)}")
+      #     print(f"[PASS] Peripherals: {len(m['peripherals'])}")
+      #     EOF
+      - name: Skip CAD pipeline (eFab unavailable)
         run: |
-          python3 tools/cad_pipeline.py \
-            eFab/samples/eos_reference_board.kicad_pcb \
-            cad_output/
-          echo "=== Validating generated artifacts ==="
-          test -f cad_output/eos_generated.ld   && echo "[PASS] Linker script" || exit 1
-          test -f cad_output/eos_generated.dts  && echo "[PASS] Device tree" || exit 1
-          test -f cad_output/eos_recipe.yaml    && echo "[PASS] ebuild recipe" || exit 1
-          test -f cad_output/eos_toolchain.cmake && echo "[PASS] CMake toolchain" || exit 1
-          test -f cad_output/board_manifest.json && echo "[PASS] Board manifest" || exit 1
-
-      - name: Validate memory map completeness
-        run: |
-          python3 - <<'EOF'
-          import json
-          with open("cad_output/board_manifest.json") as f:
-              m = json.load(f)
-          regions = {r["name"] for r in m["memory_regions"]}
-          required = {"FLASH_NOR", "RAM_LPDDR4", "UART0_PL011", "HEAP_REGION", "OTA_SCRATCH"}
-          missing = required - regions
-          if missing:
-              print(f"[FAIL] Missing memory regions: {missing}")
-              exit(1)
-          print(f"[PASS] All required memory regions present: {required}")
-          print(f"[PASS] Total regions: {len(regions)}")
-          print(f"[PASS] Peripherals: {len(m['peripherals'])}")
-          EOF
+          echo "embeddedos-org/eFab does not exist; the CAD pipeline cannot be"
+          echo "validated. Re-enable the steps above once it is published."
 
   # ── Job 5: Full stack integration summary ──────────────────────────────────
   integration-summary:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,7 +17,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
+          # No cache: pip -- this repository has neither requirements.txt nor
+          # pyproject.toml, and setup-python treats that as a hard error rather
+          # than skipping the cache.
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Twelve of the fourteen failing checks on a pull request here come from `eos-simulation.yml`, and **none of them are about the code**. They are about two sibling repositories that cannot be cloned, and a cache configured to be fatal.

## `embeddedos-org/eFab` does not exist

```
$ gh api repos/embeddedos-org/eFab
{"message":"Not Found","status":"404"}
```

```
fatal: repository 'https://github.com/embeddedos-org/eFab/' not found
```

Two jobs check it out:

- **`build-kernel`** clones it only to run `cad_pipeline.py` over `eFab/samples/eos_reference_board.kicad_pcb`. The failed checkout kills the job — which takes `simulate-qemu` and `integration-summary` with it, and the summary is the one job that hard-fails the whole workflow. Checkout and CAD step commented out; the artifact directory the upload step expects is created empty instead.
- **`test-cad-pipeline`** exists only to exercise eFab. Its steps are commented out and replaced with one that says why.

## `embeddedos-org/eVera` does not exist either

Same 404, from the `test-middleware` matrix. Removed from the matrix, and the job's display name updated to match. The other ten repositories in that matrix do exist.

## `cache: pip` is a hard failure, not a fallback

```
No file in /home/runner/work/eos/eos matched to
[**/requirements.txt or **/pyproject.toml], make sure you have checked out
the target repository
```

`setup-python` errors when the repository it is caching for has neither file — true of this repository and of most of the middleware matrix. **Eight matrix jobs died on this before running a single test.** Dropped from both `eos-simulation.yml` and `python-tests.yml`: a dependency cache is an optimisation, and failing a job over a missing lockfile is not a trade worth making.

## Two more of a defect this repo has elsewhere

Both in `build-kernel`, and both the same shape as things already fixed in #75:

| | |
|---|---|
| `-DBOARD=qemu_arm64` | eBoot's option is **`EBLDR_BOARD`**. This set an unrelated cache variable, so the board silently defaulted to `none` — **the ARM64 board port was never being built.** |
| `-DCMAKE_TOOLCHAIN_FILE=cmake/aarch64-linux-gnu.cmake` | `cmake/` holds only `cppcheck.cmake`, `deps.cmake`, `ebuild_layers.cmake`. The toolchain file is in **`toolchains/`**. Identical to the ARM job defect fixed in #75. |

## Verification

| Check | Result |
|---|---|
| `ctest --no-tests=error` | **26/26 pass** |
| both workflow files | parse |

Everything removed is **commented, not deleted** — restoring it is a revert once the repositories are published.

## What this does *not* fix

Stated plainly so the remaining red is not a surprise:

- **`Host Tests (x86_64)`** (`tests/test_e2e.c` under `-Werror`) and **`Cross-compile ARM Cortex-M4`** (missing `-Ihal/include`) are the other two failures. **#71 already fixes both** and I have deliberately not duplicated a maintainer's open PR.
- **`build-kernel` will still fail at its eBoot build step** until eBoot's `master` compiles again. That is eBoot #55/#57/#58 — nothing this repository can do about it. With `-DEBLDR_BOARD=qemu_arm64` now actually taking effect, that step will build more than it used to, so it may surface eBoot board-port errors that the silent `none` fallback was hiding.
