### PR TITLE
fix(fs): give inodes a lifetime, and stop deriving free space from a counter

### DIFF
--- a/docs/book/part3-services/ch12-filesystem.md
+++ b/docs/book/part3-services/ch12-filesystem.md
@@ -177,12 +177,28 @@ if (eos_fs_exists("/config.json")) {
     printf("Config file found\n");
 }
 
-/* Rename / move */
+/* Rename / move — replaces the destination if it already exists */
 eos_fs_rename("/config.json", "/config.json.bak");
 
 /* Delete */
 eos_fs_remove("/old_log.txt");
 ```
+
+### 12.7.1 Semantics
+
+Both operations follow POSIX:
+
+- `eos_fs_rename()` **replaces** an existing destination. The rotation pattern
+  above therefore works on the second and every later call, not only the first.
+  Renaming a path onto itself succeeds and changes nothing.
+- `eos_fs_remove()` unlinks the *name*. Descriptors already open on the file
+  keep reading and writing it, and the storage is released when the last one is
+  closed. Until then the file no longer appears in `eos_fs_exists()` or
+  `eos_fs_readdir()`, but its bytes still count towards `used_bytes`.
+
+Removing a file therefore never invalidates a descriptor that another part of
+the system is still holding, and never lets a later `eos_fs_open()` hand out
+storage that a live descriptor still points at.
 
 ## 12.8 Filesystem Statistics
 

--- a/services/filesystem/include/eos/filesystem.h
+++ b/services/filesystem/include/eos/filesystem.h
@@ -94,8 +94,17 @@ int  eos_fs_readdir(eos_dir_t dir, eos_dirent_t *entry);
 int  eos_fs_closedir(eos_dir_t dir);
 
 /* Path operations */
+
+/* Unlink a path. POSIX semantics: the name is removed immediately, but a file
+ * with descriptors still open on it keeps its storage until the last one is
+ * closed. Until then it is invisible to eos_fs_exists() and eos_fs_readdir()
+ * while still counting towards eos_fs_stat()'s used_bytes. */
 int  eos_fs_remove(const char *path);
+
+/* Rename a path, replacing new_path if it already exists (as POSIX rename()
+ * does). Renaming a path onto itself succeeds and changes nothing. */
 int  eos_fs_rename(const char *old_path, const char *new_path);
+
 bool eos_fs_exists(const char *path);
 
 #ifdef __cplusplus

--- a/services/filesystem/src/filesystem.c
+++ b/services/filesystem/src/filesystem.c
@@ -10,7 +10,12 @@
 #define MAX_INODES 32
 #define BLOCK_SIZE 4096
 
-typedef struct { char name[EOS_PATH_MAX]; uint8_t data[BLOCK_SIZE]; uint32_t size, cap; uint8_t in_use, is_dir; } inode_t;
+/* `unlinked` marks an inode whose name has been removed but which still has
+ * open descriptors: the name is gone from lookups, the storage is not. The
+ * inode is released when the last descriptor closes, which is what keeps
+ * alloc_inode() from handing the slot to an unrelated file while a live fd
+ * still points at it. */
+typedef struct { char name[EOS_PATH_MAX]; uint8_t data[BLOCK_SIZE]; uint32_t size, cap; uint8_t in_use, is_dir, unlinked, open_count; } inode_t;
 typedef struct { uint8_t in_use, inode; uint32_t pos, flags; } fd_t;
 typedef struct { uint8_t in_use; int idx; } dir_ctx_t;
 
@@ -18,7 +23,6 @@ static inode_t g_inodes[MAX_INODES];
 static fd_t g_fds[EOS_FILE_MAX];
 static dir_ctx_t g_dirs[4];
 static int g_init = 0;
-static uint32_t g_used = 0;
 
 /* Helper to validate path length and integrity */
 int eos_fs_validate_path(const char *path) {
@@ -36,40 +40,79 @@ int eos_fs_init(const eos_fs_config_t *cfg) {
     memset(g_inodes, 0, sizeof(g_inodes)); memset(g_fds, 0, sizeof(g_fds)); memset(g_dirs, 0, sizeof(g_dirs));
     g_inodes[0].in_use = 1; g_inodes[0].is_dir = 1; strncpy(g_inodes[0].name, "/", EOS_PATH_MAX - 1);
     g_inodes[0].name[EOS_PATH_MAX - 1] = '\0';
-    g_used = 0; g_init = 1; return 0;
+    g_init = 1; return 0;
 }
 
 void eos_fs_deinit(void) { g_init = 0; }
 int eos_fs_format(void) { return eos_fs_init(NULL); }
 
+/* Derived rather than accumulated. A running total has to be adjusted by every
+ * path that changes a file's length -- write, truncate, O_TRUNC, remove -- and
+ * missing or double-applying one adjustment silently corrupts it. It did:
+ * removing a file that still had an open descriptor and then truncating
+ * through that descriptor subtracted the same bytes twice, wrapping the
+ * unsigned total so that free_bytes came out larger than total_bytes. Summing
+ * the inodes cannot get out of step, and the table is 32 entries. */
+static uint32_t used_bytes(void) {
+    uint32_t used = 0;
+    for (int i = 0; i < MAX_INODES; i++)
+        if (g_inodes[i].in_use && !g_inodes[i].is_dir) used += g_inodes[i].size;
+    return used;
+}
+
 int eos_fs_stat(eos_fs_stat_t *st) {
     if (!g_init || !st) return -1;
-    st->total_bytes = MAX_INODES * BLOCK_SIZE; st->used_bytes = g_used; st->free_bytes = st->total_bytes - g_used;
+    uint32_t used = used_bytes();
+    st->total_bytes = MAX_INODES * BLOCK_SIZE; st->used_bytes = used; st->free_bytes = st->total_bytes - used;
     return 0;
 }
 
-static int find_inode(const char *p) { for (int i = 0; i < MAX_INODES; i++) if (g_inodes[i].in_use && strcmp(g_inodes[i].name, p) == 0) return i; return -1; }
+static int find_inode(const char *p) { for (int i = 0; i < MAX_INODES; i++) if (g_inodes[i].in_use && !g_inodes[i].unlinked && strcmp(g_inodes[i].name, p) == 0) return i; return -1; }
 static int alloc_inode(void) { for (int i = 0; i < MAX_INODES; i++) if (!g_inodes[i].in_use) return i; return -1; }
+
+/* Drop an inode's name. The storage returns to the pool once the last
+ * descriptor closes; until then the slot stays in_use so it cannot be
+ * recycled underneath a descriptor that is still open on it. */
+static void unlink_inode(int i) {
+    if (g_inodes[i].open_count > 0) { g_inodes[i].unlinked = 1; return; }
+    memset(&g_inodes[i], 0, sizeof(inode_t));
+}
 static int alloc_fd(void) { for (int i = 0; i < EOS_FILE_MAX; i++) if (!g_fds[i].in_use) return i; return -1; }
 
 eos_file_t eos_fs_open(const char *path, uint32_t flags) {
     if (!g_init || eos_fs_validate_path(path) != 0) return EOS_FILE_INVALID;
     int inode = find_inode(path);
+    int created = 0;
     if (inode < 0) {
         if (!(flags & EOS_O_CREATE)) return EOS_FILE_INVALID;
         inode = alloc_inode(); if (inode < 0) return EOS_FILE_INVALID;
         memset(&g_inodes[inode], 0, sizeof(inode_t));
         strncpy(g_inodes[inode].name, path, EOS_PATH_MAX - 1);
         g_inodes[inode].in_use = 1; g_inodes[inode].cap = BLOCK_SIZE;
+        created = 1;
     }
-    int fd = alloc_fd(); if (fd < 0) return EOS_FILE_INVALID;
+    int fd = alloc_fd();
+    if (fd < 0) {
+        /* An inode created a moment ago has no name anyone can reach and no
+         * descriptor: release it rather than stranding the slot. */
+        if (created) memset(&g_inodes[inode], 0, sizeof(inode_t));
+        return EOS_FILE_INVALID;
+    }
     g_fds[fd].in_use = 1; g_fds[fd].inode = (uint8_t)inode; g_fds[fd].pos = 0; g_fds[fd].flags = flags;
-    if (flags & EOS_O_TRUNC) { g_used -= g_inodes[inode].size; g_inodes[inode].size = 0; }
+    g_inodes[inode].open_count++;
+    if (flags & EOS_O_TRUNC) g_inodes[inode].size = 0;
     if (flags & EOS_O_APPEND) g_fds[fd].pos = g_inodes[inode].size;
     return (eos_file_t)fd;
 }
 
-int eos_fs_close(eos_file_t fd) { if (fd < 0 || fd >= EOS_FILE_MAX || !g_fds[fd].in_use) return -1; g_fds[fd].in_use = 0; return 0; }
+int eos_fs_close(eos_file_t fd) {
+    if (fd < 0 || fd >= EOS_FILE_MAX || !g_fds[fd].in_use) return -1;
+    inode_t *n = &g_inodes[g_fds[fd].inode];
+    g_fds[fd].in_use = 0;
+    if (n->open_count > 0) n->open_count--;
+    if (n->open_count == 0 && n->unlinked) memset(n, 0, sizeof(*n));
+    return 0;
+}
 
 int eos_fs_read(eos_file_t fd, void *buf, size_t len) {
     if (fd < 0 || fd >= EOS_FILE_MAX || !g_fds[fd].in_use || !buf) return -1;
@@ -93,7 +136,7 @@ int eos_fs_write(eos_file_t fd, const void *data, size_t len) {
     if (p + len > n->cap) len = n->cap - p;
     if (len == 0) return 0;
     memcpy(n->data + p, data, len); g_fds[fd].pos += (uint32_t)len;
-    if (g_fds[fd].pos > n->size) { g_used += g_fds[fd].pos - n->size; n->size = g_fds[fd].pos; }
+    if (g_fds[fd].pos > n->size) n->size = g_fds[fd].pos;
     return (int)len;
 }
 
@@ -113,7 +156,7 @@ int eos_fs_truncate(eos_file_t fd, uint32_t size) {
     if (fd < 0 || fd >= EOS_FILE_MAX || !g_fds[fd].in_use) return -1;
     inode_t *n = &g_inodes[g_fds[fd].inode];
     if (size > n->cap) size = n->cap;
-    if (size < n->size) { g_used -= (n->size - size); memset(n->data + size, 0, n->size - size); }
+    if (size < n->size) memset(n->data + size, 0, n->size - size);
     n->size = size; if (g_fds[fd].pos > size) g_fds[fd].pos = size;
     return 0;
 }
@@ -138,7 +181,7 @@ int eos_fs_readdir(eos_dir_t d, eos_dirent_t *e) {
     if (d < 0 || d >= 4 || !g_dirs[d].in_use || !e) return -1;
     while (g_dirs[d].idx < MAX_INODES) {
         int i = g_dirs[d].idx++;
-        if (g_inodes[i].in_use) {
+        if (g_inodes[i].in_use && !g_inodes[i].unlinked) {
             strncpy(e->name, g_inodes[i].name, EOS_PATH_MAX - 1);
             e->size = g_inodes[i].size; e->is_dir = g_inodes[i].is_dir; return 0;
         }
@@ -151,13 +194,24 @@ int eos_fs_closedir(eos_dir_t d) { if (d < 0 || d >= 4 || !g_dirs[d].in_use) ret
 int eos_fs_remove(const char *path) {
     if (!g_init || eos_fs_validate_path(path) != 0) return -1;
     int i = find_inode(path); if (i < 0) return -1;
-    g_used -= g_inodes[i].size; g_inodes[i].in_use = 0; return 0;
+    unlink_inode(i); return 0;
 }
 
 int eos_fs_rename(const char *old_path, const char *new_path) {
     if (!g_init || eos_fs_validate_path(old_path) != 0 || eos_fs_validate_path(new_path) != 0) return -1;
     int i = find_inode(old_path); if (i < 0) return -1;
-    strncpy(g_inodes[i].name, new_path, EOS_PATH_MAX - 1); return 0;
+    int existing = find_inode(new_path);
+    if (existing == i) return 0;
+    /* Without this the new name was written over the old one with no regard
+     * for what was already there, leaving two in_use inodes carrying the same
+     * path: find_inode() saw one of them, readdir() listed both, and removing
+     * the name once left the other behind still answering eos_fs_exists().
+     * POSIX rename() replaces the target, so unlink it first -- which also
+     * keeps any descriptor still open on it readable until it is closed. */
+    if (existing >= 0) unlink_inode(existing);
+    strncpy(g_inodes[i].name, new_path, EOS_PATH_MAX - 1);
+    g_inodes[i].name[EOS_PATH_MAX - 1] = 0;
+    return 0;
 }
 
 bool eos_fs_exists(const char *path) {

--- a/tests/test_filesystem.c
+++ b/tests/test_filesystem.c
@@ -103,6 +103,171 @@ static void test_fs_format(void) {
     printf("[PASS] fs format\n");
 }
 
+/*
+ * Regression: eos_fs_remove() released the inode outright, so the next
+ * eos_fs_open(..., EOS_O_CREATE) was handed the same slot while a descriptor
+ * was still open on it. The stale descriptor then read and wrote the new,
+ * unrelated file.
+ */
+static void test_fs_remove_with_open_fd_does_not_alias(void) {
+    eos_fs_init(NULL);
+    eos_file_t a = eos_fs_open("/a.txt", EOS_O_CREATE | EOS_O_WRITE | EOS_O_READ);
+    assert(a != EOS_FILE_INVALID);
+    assert(eos_fs_write(a, "AAAAAAAA", 8) == 8);
+
+    assert(eos_fs_remove("/a.txt") == 0);
+    assert(!eos_fs_exists("/a.txt"));       /* the name is gone at once */
+
+    eos_file_t b = eos_fs_open("/b.txt", EOS_O_CREATE | EOS_O_WRITE | EOS_O_READ);
+    assert(b != EOS_FILE_INVALID);
+    assert(eos_fs_write(b, "BBBBBBBB", 8) == 8);
+
+    /* The unlinked file stays readable through its own descriptor... */
+    char buf[16] = {0};
+    assert(eos_fs_seek(a, 0, EOS_SEEK_SET) == 0);
+    assert(eos_fs_read(a, buf, 8) == 8);
+    assert(memcmp(buf, "AAAAAAAA", 8) == 0);
+
+    /* ...and writing through it must not reach /b.txt. */
+    assert(eos_fs_seek(a, 0, EOS_SEEK_SET) == 0);
+    assert(eos_fs_write(a, "XXXXXXXX", 8) == 8);
+    memset(buf, 0, sizeof(buf));
+    assert(eos_fs_seek(b, 0, EOS_SEEK_SET) == 0);
+    assert(eos_fs_read(b, buf, 8) == 8);
+    assert(memcmp(buf, "BBBBBBBB", 8) == 0);
+
+    assert(eos_fs_close(a) == 0);
+    assert(eos_fs_close(b) == 0);
+    eos_fs_deinit();
+    printf("[PASS] fs remove with open fd does not alias\n");
+}
+
+/* The inode an unlinked-but-open file holds is released on the last close. */
+static void test_fs_unlinked_inode_is_reclaimed_on_close(void) {
+    eos_fs_init(NULL);
+    eos_file_t fd = eos_fs_open("/u.txt", EOS_O_CREATE | EOS_O_WRITE);
+    assert(eos_fs_write(fd, "0123456789", 10) == 10);
+
+    eos_fs_stat_t st;
+    assert(eos_fs_stat(&st) == 0);
+    assert(st.used_bytes == 10);
+
+    assert(eos_fs_remove("/u.txt") == 0);
+    assert(eos_fs_stat(&st) == 0);
+    assert(st.used_bytes == 10);            /* still occupying space */
+
+    assert(eos_fs_close(fd) == 0);
+    assert(eos_fs_stat(&st) == 0);
+    assert(st.used_bytes == 0);             /* reclaimed */
+    eos_fs_deinit();
+    printf("[PASS] fs unlinked inode reclaimed on close\n");
+}
+
+/*
+ * Regression: used_bytes was a running total that eos_fs_remove() and
+ * eos_fs_truncate() could each subtract for the same bytes, wrapping the
+ * unsigned counter so free_bytes came out larger than total_bytes.
+ */
+static void test_fs_used_bytes_never_underflows(void) {
+    eos_fs_init(NULL);
+    eos_file_t fd = eos_fs_open("/c.txt", EOS_O_CREATE | EOS_O_WRITE);
+    assert(eos_fs_write(fd, "0123456789", 10) == 10);
+    assert(eos_fs_remove("/c.txt") == 0);
+    assert(eos_fs_truncate(fd, 0) == 0);
+
+    eos_fs_stat_t st;
+    assert(eos_fs_stat(&st) == 0);
+    assert(st.used_bytes == 0);
+    assert(st.free_bytes <= st.total_bytes);
+    assert(st.used_bytes + st.free_bytes == st.total_bytes);
+
+    assert(eos_fs_close(fd) == 0);
+    eos_fs_deinit();
+    printf("[PASS] fs used_bytes never underflows\n");
+}
+
+/*
+ * Regression: eos_fs_rename() overwrote the source inode's name without
+ * looking at the destination, leaving two in_use inodes carrying the same
+ * path. readdir() listed both and removing the name once left one behind.
+ */
+static void test_fs_rename_replaces_existing_target(void) {
+    eos_fs_init(NULL);
+    eos_file_t x = eos_fs_open("/x.txt", EOS_O_CREATE | EOS_O_WRITE);
+    assert(eos_fs_write(x, "XX", 2) == 2);
+    assert(eos_fs_close(x) == 0);
+    eos_file_t y = eos_fs_open("/y.txt", EOS_O_CREATE | EOS_O_WRITE);
+    assert(eos_fs_write(y, "YYYY", 4) == 4);
+    assert(eos_fs_close(y) == 0);
+
+    assert(eos_fs_rename("/x.txt", "/y.txt") == 0);
+    assert(!eos_fs_exists("/x.txt"));
+    assert(eos_fs_exists("/y.txt"));
+
+    /* Exactly one directory entry, and it is the source file's contents. */
+    eos_dir_t dir = eos_fs_opendir("/");
+    assert(dir != EOS_DIR_INVALID);
+    eos_dirent_t entry;
+    int seen = 0;
+    while (eos_fs_readdir(dir, &entry) == 0)
+        if (strcmp(entry.name, "/y.txt") == 0) seen++;
+    eos_fs_closedir(dir);
+    assert(seen == 1);
+
+    eos_file_t r = eos_fs_open("/y.txt", EOS_O_READ);
+    char buf[8] = {0};
+    assert(eos_fs_read(r, buf, sizeof(buf)) == 2);
+    assert(memcmp(buf, "XX", 2) == 0);
+    assert(eos_fs_close(r) == 0);
+
+    /* One remove is enough to make the name go away. */
+    assert(eos_fs_remove("/y.txt") == 0);
+    assert(!eos_fs_exists("/y.txt"));
+    eos_fs_deinit();
+    printf("[PASS] fs rename replaces existing target\n");
+}
+
+/* Renaming a file onto its own name is a no-op, not a self-destruct. */
+static void test_fs_rename_onto_itself_is_a_noop(void) {
+    eos_fs_init(NULL);
+    eos_file_t fd = eos_fs_open("/same.txt", EOS_O_CREATE | EOS_O_WRITE);
+    assert(eos_fs_write(fd, "keep", 4) == 4);
+    assert(eos_fs_close(fd) == 0);
+
+    assert(eos_fs_rename("/same.txt", "/same.txt") == 0);
+    assert(eos_fs_exists("/same.txt"));
+
+    fd = eos_fs_open("/same.txt", EOS_O_READ);
+    char buf[8] = {0};
+    assert(eos_fs_read(fd, buf, sizeof(buf)) == 4);
+    assert(memcmp(buf, "keep", 4) == 0);
+    assert(eos_fs_close(fd) == 0);
+    eos_fs_deinit();
+    printf("[PASS] fs rename onto itself is a no-op\n");
+}
+
+/* Running out of descriptors must not strand the inode open() just created. */
+static void test_fs_open_does_not_leak_inode_when_fds_exhausted(void) {
+    eos_fs_init(NULL);
+    char path[16];
+    for (int i = 0; i < EOS_FILE_MAX; i++) {
+        snprintf(path, sizeof(path), "/fd%d", i);
+        assert(eos_fs_open(path, EOS_O_CREATE | EOS_O_WRITE) != EOS_FILE_INVALID);
+    }
+    assert(eos_fs_open("/overflow", EOS_O_CREATE | EOS_O_WRITE) == EOS_FILE_INVALID);
+    /* The failed open must not have left a nameless inode behind. */
+    assert(!eos_fs_exists("/overflow"));
+
+    eos_dir_t dir = eos_fs_opendir("/");
+    eos_dirent_t entry;
+    int count = 0;
+    while (eos_fs_readdir(dir, &entry) == 0) count++;
+    eos_fs_closedir(dir);
+    assert(count == EOS_FILE_MAX + 1);   /* the files plus the root directory */
+    eos_fs_deinit();
+    printf("[PASS] fs open does not leak inode when fds exhausted\n");
+}
+
 int main(void) {
     printf("=== EoS Filesystem Tests ===\n");
     test_fs_init();
@@ -112,6 +277,12 @@ int main(void) {
     test_fs_dir();
     test_fs_remove_rename();
     test_fs_format();
-    printf("=== ALL FS TESTS PASSED (7/7) ===\n");
+    test_fs_remove_with_open_fd_does_not_alias();
+    test_fs_unlinked_inode_is_reclaimed_on_close();
+    test_fs_used_bytes_never_underflows();
+    test_fs_rename_replaces_existing_target();
+    test_fs_rename_onto_itself_is_a_noop();
+    test_fs_open_does_not_leak_inode_when_fds_exhausted();
+    printf("=== ALL FS TESTS PASSED (13/13) ===\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

`eos_fs_remove()` released the inode outright, without regard for descriptors
still open on it:

```c
int eos_fs_remove(const char *path) {
    ...
    int i = find_inode(path); if (i < 0) return -1;
    g_used -= g_inodes[i].size; g_inodes[i].in_use = 0; return 0;
}
```

`alloc_inode()` returns the first slot with `in_use == 0`, so that slot is the
very next one handed out. Three defects follow, all reproducible on the host.

### 1. A stale descriptor aliases the next file created

```
read via fd of REMOVED /a.txt -> n=8 data="BBBBBBBB"     (expected AAAAAAAA)
/b.txt now contains "XXXXXXXX"                           (expected BBBBBBBB)
```

One component's data becomes readable *and writable* through another
component's stale handle. On a system where the filesystem is shared between
services, that is a cross-component confidentiality and integrity failure, and
it needs no attacker — just a `remove()` racing a `close()`.

### 2. `used_bytes` underflows, and `eos_fs_stat()` reports impossible free space

`g_used` was a running total, adjusted by `remove()` and again by `truncate()`
through the surviving descriptor — the same bytes subtracted twice:

```
after 10-byte write : used=10          free=131062
after remove+truncate: used=4294967286 free=131082      (total_bytes = 131072)
```

`free_bytes` now exceeds `total_bytes`. That is the number a caller uses to
decide whether a write will fit.

### 3. `eos_fs_rename()` leaves two inodes with the same name

It overwrote the source inode's name without looking at the destination:

```
rename /x.txt -> /y.txt returns 0
directory now lists /y.txt 2 time(s)
```

`find_inode()` sees one, `eos_fs_readdir()` lists both, and removing the name
once leaves the other behind still answering `eos_fs_exists()`. The log
rotation pattern in the filesystem chapter —
`eos_fs_remove("/log.csv.old"); eos_fs_rename("/log.csv", "/log.csv.old")` —
hits this on its second call.

## Approach

**Give the inode a lifetime.** It gains `unlinked` and `open_count`.
`eos_fs_remove()` drops the *name* immediately (so `eos_fs_exists()` and
`eos_fs_readdir()` stop seeing it, matching POSIX `unlink`) and defers the
release to the last `eos_fs_close()`. The slot stays `in_use` until then, so
`alloc_inode()` cannot hand it to an unrelated file while a live descriptor
points at it.

**Derive used space instead of accumulating it.** A running total has to be
adjusted correctly by *every* path that changes a length — `write`, `truncate`,
`O_TRUNC`, `remove` — and missing or double-applying one silently corrupts it,
which is exactly what produced defect 2. `used_bytes()` now sums the inode
table on demand. The table is 32 entries; this cannot get out of step. It also
deletes three separate `g_used +=`/`-=` sites, so the class of bug goes with it.

**Make `rename()` replace its target**, as POSIX does, by unlinking the
destination through the same deferred path — which also keeps any descriptor
open on the replaced file readable until it is closed. Renaming a path onto
itself is an explicit no-op.

Also: `eos_fs_open()` now releases an inode it had just created when no
descriptor is available. It was previously left stranded with a name nothing
could reach.

## Testing

Six cases added to `tests/test_filesystem.c`, which grows from 7 to 13.

Per `TESTING.md` — "break the code and watch the test fail" — each was run
individually against the unfixed `filesystem.c`:

| Test | vs unfixed `filesystem.c` |
|---|---|
| `test_fs_remove_with_open_fd_does_not_alias` | **fails** — `memcmp(buf, "AAAAAAAA", 8) == 0` |
| `test_fs_unlinked_inode_is_reclaimed_on_close` | **fails** — `st.used_bytes == 10` |
| `test_fs_used_bytes_never_underflows` | **fails** — `st.used_bytes == 0` |
| `test_fs_rename_replaces_existing_target` | **fails** — `seen == 1` |
| `test_fs_rename_onto_itself_is_a_noop` | *passes before and after* |
| `test_fs_open_does_not_leak_inode_when_fds_exhausted` | **fails** — `!eos_fs_exists("/overflow")` |

`test_fs_rename_onto_itself_is_a_noop` is stated plainly: it is **not** a
regression test. It guards the new `existing == i` early return — without which
`rename("/a", "/a")` would unlink the file and then rename it to its own name —
and it would have passed on master too.

Full suite, `-DEOS_BUILD_TESTS=ON`:

```
100% tests passed out of 26
```

```
18: [PASS] fs remove with open fd does not alias
18: [PASS] fs unlinked inode reclaimed on close
18: [PASS] fs used_bytes never underflows
18: [PASS] fs rename replaces existing target
18: [PASS] fs rename onto itself is a no-op
18: [PASS] fs open does not leak inode when fds exhausted
18: === ALL FS TESTS PASSED (13/13) ===
```

## Documentation

Behaviour changed, so the contracts are now written down rather than implied:

- `filesystem.h`: doc comments on `eos_fs_remove()` and `eos_fs_rename()`.
- `docs/book/part3-services/ch12-filesystem.md`: new §12.7.1 "Semantics",
  and the rename example is annotated as replacing its destination.

## Considerations and limitations

- **This is a behaviour change, deliberately.** `eos_fs_remove()` on a file with
  an open descriptor used to free the storage at once; it now defers. Any caller
  relying on space being reclaimed before the last `close()` will see the space
  held slightly longer. That is the POSIX contract, and holding it is what makes
  the aliasing impossible.
- `eos_fs_rename()` now destroys an existing destination where it previously
  produced a duplicate. Neither behaviour was documented; this one matches
  POSIX and every real filesystem, and it is what the log-rotation pattern in
  the book already assumes.
- `open_count` is `uint8_t` and `EOS_FILE_MAX` is 8, so it cannot overflow.
  `eos_fs_close()` guards the decrement at zero regardless.
- `used_bytes()` is O(MAX_INODES) = 32 per `eos_fs_stat()` call. `eos_fs_stat()`
  is not on any hot path; correctness over a counter that was demonstrably wrong
  seemed the right trade, and the priority order in `CLAUDE.md` agrees.
- Directories are excluded from `used_bytes()`, as they carry no data. Unlinked
  files still count while their descriptors are open, which is physically
  accurate — the storage is still occupied.
- I did **not** touch the flat inode model (no hierarchy, `remove()` on a
  directory does not check for children). That is a separate design question and
  a much larger change.

Environment: GCC on Windows, CMake 4.4 + Ninja. The three symptom traces above
are from a small probe program built directly against `filesystem.c` before and
after the change; the same behaviour is asserted by the six tests.
