### PR TITLE
docs: make the quick start clone a repository that exists

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -46,15 +46,15 @@ Best for: nRF52840-DK, nRF52832-DK, or custom nRF52 boards.
 
 ### 1. Clone the repository
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS
+git clone https://github.com/embeddedos-org/eos.git
+cd eos
 ```
 
 ### 2. Build the blink example
 ```bash
 cd eos/examples/blink-gpio
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 ```
@@ -96,11 +96,11 @@ Best for: STM32H743-Nucleo, STM32F4-Discovery, or custom STM32 boards.
 
 ### 1. Clone and build
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```
@@ -128,8 +128,8 @@ Build and run on your development machine — no MCU needed.
 
 ### 1. Clone and build
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 # Host build uses Linux HAL backend (simulated GPIO via sysfs/printf)
 cmake -B build -DEOS_PRODUCT=iot -DEOS_BUILD_TESTS=ON
@@ -264,7 +264,7 @@ This produces:
 ### 3. Sign and flash
 ```bash
 # Create signing key (first time only)
-cd EoS/eboot/tools
+cd eBoot/tools
 python3 sign_image.py --generate-key my-key.pem
 
 # Sign firmware

--- a/docs/book/part1-foundations/ch01-introduction.md
+++ b/docs/book/part1-foundations/ch01-introduction.md
@@ -227,7 +227,7 @@ For cross-compilation to a specific board:
 
 ```bash
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```

--- a/docs/book/part1-foundations/ch02-getting-started.md
+++ b/docs/book/part1-foundations/ch02-getting-started.md
@@ -270,7 +270,7 @@ done
 cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```
@@ -376,7 +376,7 @@ sudo apt install gcc-arm-none-eabi
 cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 

--- a/docs/book/part1-foundations/ch03-architecture.md
+++ b/docs/book/part1-foundations/ch03-architecture.md
@@ -338,7 +338,7 @@ Toolchains are YAML-based definitions specifying CC, CXX, AR, sysroot, and flags
 Usage:
 
 ```bash
-cmake -B build -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake
 `
 
 ## 3.9 Configuration Schema Summary

--- a/docs/book/part4-ecosystem/ch17-eboot.md
+++ b/docs/book/part4-ecosystem/ch17-eboot.md
@@ -90,7 +90,7 @@ cd build && ctest
 
 ```bash
 cmake -B build-arm -DEBLDR_BOARD=stm32f4 \
-  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake
 cmake --build build-arm
 ```
 

--- a/docs/book/part5-hardware/ch25-ehealth365.md
+++ b/docs/book/part5-hardware/ch25-ehealth365.md
@@ -225,7 +225,7 @@ Both devices run EoS firmware with the `wearable` product profile:
 
 ```bash
 cmake -B build -DEOS_PRODUCT=wearable \
-  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake
 ```
 
 The firmware leverages:

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -126,7 +126,7 @@ Build your eos app with the linker script:
 ```bash
 cd EoS/eos
 cmake -B build -DEOS_PRODUCT=iot \
-  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake \
   -DEOS_LINKER_SCRIPT=../ebuild/_generated/eboot_linker.ld
 cmake --build build
 ```
@@ -135,7 +135,7 @@ cmake --build build
 
 ```bash
 # Generate signing key (first time only)
-cd EoS/eboot/tools
+cd eBoot/tools
 python3 sign_image.py --generate-key firmware-key.pem
 
 # Sign the firmware

--- a/docs/quickstart-host.md
+++ b/docs/quickstart-host.md
@@ -31,8 +31,8 @@ winget install CMake.CMake
 ## Step 1: Build an example
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build -DEOS_PRODUCT=iot
 cmake --build build
@@ -58,7 +58,7 @@ Press `Ctrl+C` to stop.
 ## Step 3: Run the full test suite
 
 ```bash
-cd EoS/eos
+cd eos
 cmake -B build -DEOS_BUILD_TESTS=ON
 cmake --build build
 ctest --test-dir build --output-on-failure
@@ -69,7 +69,7 @@ ctest --test-dir build --output-on-failure
 ## Try all examples
 
 ```bash
-cd EoS/eos/examples
+cd eos/examples
 
 # Each example builds the same way:
 for example in blink-gpio uart-echo multitask-rtos posix-app multicore-amp; do
@@ -97,7 +97,7 @@ done
 When you're ready to target an MCU:
 
 1. Install the cross-compiler (`arm-none-eabi-gcc`)
-2. Add `-DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake` to your cmake command
+2. Add `-DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake` to your cmake command
 3. Flash the resulting binary to your board
 
 Your application code stays the same — only the build command changes.

--- a/docs/quickstart-nrf52.md
+++ b/docs/quickstart-nrf52.md
@@ -35,11 +35,11 @@ nrfjprog --version              # Should print 10.x or later
 ## Step 1: Clone and build
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 ```

--- a/docs/quickstart-rpi4.md
+++ b/docs/quickstart-rpi4.md
@@ -24,8 +24,8 @@ sudo apt install cmake gcc g++ git python3 python3-pip
 
 ```bash
 # On the Raspberry Pi:
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 # Build using the Linux HAL backend (native compile on Pi)
 cmake -B build -DEOS_PRODUCT=gateway
@@ -69,7 +69,7 @@ Connect an LED + resistor (330Ω) between GPIO 18 and GND, then run.
 sudo apt install gcc-aarch64-linux-gnu
 
 # Build
-cd EoS/eos/examples/blink-gpio
+cd eos/examples/blink-gpio
 cmake -B build \
   -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
   -DEOS_PRODUCT=gateway

--- a/docs/quickstart-stm32.md
+++ b/docs/quickstart-stm32.md
@@ -29,11 +29,11 @@ brew install openocd                  # macOS
 ## Step 1: Clone and build
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```

--- a/docs/three-way-alignment.md
+++ b/docs/three-way-alignment.md
@@ -211,7 +211,7 @@ cmake --build build
 # Outputs: libeboot_hal.a, libeboot_core.a, ebldr_stage0.bin, eboot_firmware.bin
 
 # Step 5: Sign and flash (uses eboot tools)
-cd EoS/eboot/tools
+cd eBoot/tools
 python3 sign_image.py --key key.pem --input ../../eos/build/app.bin --output signed.bin
 ```
 

--- a/docs/tutorials/stm32-deployment.md
+++ b/docs/tutorials/stm32-deployment.md
@@ -112,8 +112,8 @@ sudo udevadm trigger
 ## Step 1 — Clone the Repository
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos
+git clone https://github.com/embeddedos-org/eos.git
+cd eos
 ```
 
 ---

--- a/examples/ble-sensor/README.md
+++ b/examples/ble-sensor/README.md
@@ -31,7 +31,7 @@ A complete IoT sensor node that reads temperature from an I2C sensor, computes a
 ```bash
 # Cross-compile for nRF52
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 

--- a/examples/blink-gpio/README.md
+++ b/examples/blink-gpio/README.md
@@ -25,7 +25,7 @@ cmake --build build
 
 # ARM cross-compile
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 ```

--- a/examples/ui-touchscreen/README.md
+++ b/examples/ui-touchscreen/README.md
@@ -52,7 +52,7 @@ A complete touchscreen application that builds an interactive interface with LVG
 ```bash
 # Cross-compile for ARM target
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=hmi
 cmake --build build
 


### PR DESCRIPTION
Every quick start in the tree opens with:

```bash
git clone https://github.com/anthropic/EoS.git
```

**That repository does not exist.** `gh api repos/anthropic/EoS` → 404.

It is step one of the documented onboarding path in **seven files**: `GETTING_STARTED.md`, the host/stm32/rpi4/nrf52 quickstarts, the integration guide, and the STM32 tutorial. Any external developer following the docs stopped there.

§30's 12-month framework lists **"tested quick start"** among the 0–3 month Foundation deliverables. It was not tested, and could not have been.

## Two further defects, only visible once the clone succeeds

**The path doesn't exist either.** The docs then `cd EoS/eos/examples/blink-gpio`, but cloning `eos.git` creates a directory called `eos` with `examples/` at its root. `EoS/eos/...` belongs to a multi-repo workspace the single clone command never produces.

Fixed for the single-repo quick starts. **Left alone** for the guides that genuinely describe the multi-repo workspace — their paths are correct, and what they're missing is a step that *sets the workspace up*. That's a larger documentation question than this change, and I'd rather flag it than guess at it.

**The toolchain file doesn't exist.** They pass `-DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake`. The real ARM toolchain files are `arm-cortex-m4.cmake`, `arm-none-eabi-stm32f4.cmake` and `arm-none-eabi-r5.cmake`. Pointed at `arm-cortex-m4.cmake` — the one the CI job and the Cortex-M reference class use.

## Verification

Ran the host quick start **verbatim against the published repo**, from an empty directory:

```
$ git clone https://github.com/embeddedos-org/eos.git
$ cd eos/examples/blink-gpio
$ cmake -B build -DEOS_PRODUCT=iot
$ cmake --build build
$ ./build/blink-gpio
[blink] Starting LED blink on pin 13
[blink] LED ON
[blink] LED OFF
```

**The example itself was always fine. Only the instructions were wrong.**

Docs only — no source changes, so this is independent of #82 and can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
