### PR TITLE
fix(ota): reject oversized chunks without wrapping the length add

### DIFF
--- a/services/ota/src/ota.c
+++ b/services/ota/src/ota.c
@@ -67,7 +67,10 @@ int eos_ota_begin(const eos_ota_source_t *source) {
 
 int eos_ota_write_chunk(const uint8_t *data, size_t len) {
     if (!g_ota.initialized || !g_ota.in_progress || !data) return -1;
-    if (g_ota.bytes_written + len > g_ota.total_size) return -1;
+    /* Compare against remaining space. Adding len can wrap and accept a huge chunk. */
+    if (g_ota.bytes_written > g_ota.total_size ||
+        len > (size_t)(g_ota.total_size - g_ota.bytes_written))
+        return -1;
     eos_sha256_update(&g_ota.hash_ctx, data, len);
     g_ota.bytes_written += (uint32_t)len;
     if (g_ota.progress_cb && g_ota.total_size > 0) {

--- a/tests/test_ota.c
+++ b/tests/test_ota.c
@@ -4,6 +4,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <assert.h>
 #include "eos/ota.h"
 #include "eos/crypto.h"
@@ -130,7 +132,6 @@ static void test_ota_status(void) {
     printf("[PASS] ota status\n");
 }
 
-
 /* expected_sha256 arrives with the update, so an attacker who swaps the image
  * swaps the digest too. Passing eos_ota_verify() must not be enough to install. */
 static void test_ota_apply_refuses_without_authenticator(void) {
@@ -200,6 +201,43 @@ static void test_ota_unapplied_slot_is_not_a_rollback_target(void) {
     printf("[PASS] ota unapplied slot is not a rollback target\n");
 }
 
+static void test_ota_write_chunk_overflow(void) {
+    eos_ota_init();
+    uint8_t fw[64];
+    memset(fw, 0xAA, sizeof(fw));
+    eos_ota_source_t src;
+    memset(&src, 0, sizeof(src));
+    src.expected_size = sizeof(fw);
+    assert(eos_ota_begin(&src) == 0);
+    assert(eos_ota_write_chunk(fw, 32) == 0);
+    assert(eos_ota_write_chunk(fw, 33) == -1);
+
+    eos_ota_status_t st;
+    assert(eos_ota_get_status(&st) == 0);
+    assert(st.bytes_received == 32);
+    eos_ota_deinit();
+    printf("[PASS] ota write chunk overflow\n");
+}
+
+static void test_ota_write_chunk_wrap(void) {
+    eos_ota_init();
+    uint8_t fw[64];
+    memset(fw, 0xAA, sizeof(fw));
+    eos_ota_source_t src;
+    memset(&src, 0, sizeof(src));
+    src.expected_size = sizeof(fw);
+    assert(eos_ota_begin(&src) == 0);
+    /* One accepted byte so bytes_written + SIZE_MAX wraps on the old add. */
+    assert(eos_ota_write_chunk(fw, 1) == 0);
+    assert(eos_ota_write_chunk(fw, SIZE_MAX) == -1);
+
+    eos_ota_status_t st;
+    assert(eos_ota_get_status(&st) == 0);
+    assert(st.bytes_received == 1);
+    eos_ota_deinit();
+    printf("[PASS] ota write chunk wrap\n");
+}
+
 int main(void) {
     printf("=== EoS OTA Tests ===\n");
     test_ota_init();
@@ -211,6 +249,8 @@ int main(void) {
     test_ota_apply_honours_a_rejecting_authenticator();
     test_ota_authenticator_sees_the_computed_digest();
     test_ota_unapplied_slot_is_not_a_rollback_target();
-    printf("=== ALL OTA TESTS PASSED (9/9) ===\n");
+    test_ota_write_chunk_overflow();
+    test_ota_write_chunk_wrap();
+    printf("=== ALL OTA TESTS PASSED (11/11) ===\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

`eos_ota_write_chunk` takes a host-controlled length and used `bytes_written + len > total_size`. That add can wrap, so a huge chunk can look in-range, then SHA-256 is updated with that length. This PR compares against remaining space and adds host tests for overflow and wrap.

This addresses:

- **Issue:** integer wrap on the OTA write-chunk bound
- **Approach:** reject using remaining bytes, not a summed length
- **Testing:** new overflow and wrap tests; existing full-update path unchanged
- **Limits:** write-chunk bound only; no flash, transport, or slot-size vs `expected_size`; no hardware run on this machine

## Type of Change

- [ ] feat — New feature
- [x] fix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] refactor — Code restructuring without behavior change
- [x] test — Add or fix tests
- [ ] build — Build system or dependency changes
- [ ] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

- Reject a chunk when `len` is larger than remaining update size, without adding the two values
- Added a host test that writes 32 then 33 bytes into a 64-byte update and checks the second write is rejected
- Added a host test that accepts one byte then rejects `SIZE_MAX`, so the old wrap cannot fail open

## Testing

- [ ] Unit tests pass (`ctest --test-dir build --output-on-failure`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [x] New tests added for new functionality

CMake and a C compiler were not available on the Windows host used for this change. Please run a native build with `EOS_BUILD_TESTS=ON` and `ctest -R test_ota` before merge.

## Pre-Submission Checklist

- [ ] Code compiles without warnings (`-Wall -Wextra -Werror` for C)
- [ ] All existing tests pass
- [x] New tests added for new functionality
- [ ] Documentation updated if API changed
- [x] Commit messages follow `<type>(<scope>): <description>` convention
- [ ] Branch is rebased on latest master

## Related Issues

None. Found while reviewing the OTA write path for the screening.

## Screenshots / Logs

Not applicable. Host unit tests only; no board or OTA capture.

## Additional Notes

- Only the write-chunk bound. Slot size vs `expected_size`, transport, and apply/reboot are unchanged.
- After a rejected chunk, `bytes_received` must not move (covered by the new tests).
- Tests are host-side; they do not programme flash.