### PR TITLE
fix(hal): eos_hal_init() selects the platform backend, as hal.h says it does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           cmake -B build/arm -G Ninja \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-            -DCMAKE_TOOLCHAIN_FILE=cmake/arm-cortex-m4.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake \
             -DEOS_BUILD_TESTS=OFF
 
       - name: Build (ARM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,19 @@ add_library(eos_net STATIC
     net/src/net.c
 )
 
+# ADR-014 point 3 — on a host OS the eNet API maps onto POSIX sockets.
+#
+# Gated on CMAKE_CROSSCOMPILING alone, deliberately not on the
+# `EOS_PLATFORM STREQUAL "linux" OR ...` form used above for hal_linux.c:
+# EOS_PLATFORM defaults to "linux" and a cross toolchain file does not change
+# it, so that condition is true even for a Cortex-M build. hal_linux.c happens
+# to survive that because it uses only portable headers; net_posix.c needs
+# <netdb.h> and <sys/socket.h>, which bare-metal newlib does not have.
+if(NOT CMAKE_CROSSCOMPILING)
+    target_sources(eos_net PRIVATE net/src/net_posix.c)
+    target_compile_definitions(eos_net PRIVATE EOS_NET_POSIX=1)
+endif()
+
 target_include_directories(eos_net PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/net/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -46,15 +46,15 @@ Best for: nRF52840-DK, nRF52832-DK, or custom nRF52 boards.
 
 ### 1. Clone the repository
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS
+git clone https://github.com/embeddedos-org/eos.git
+cd eos
 ```
 
 ### 2. Build the blink example
 ```bash
 cd eos/examples/blink-gpio
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 ```
@@ -96,11 +96,11 @@ Best for: STM32H743-Nucleo, STM32F4-Discovery, or custom STM32 boards.
 
 ### 1. Clone and build
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```
@@ -128,8 +128,8 @@ Build and run on your development machine — no MCU needed.
 
 ### 1. Clone and build
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 # Host build uses Linux HAL backend (simulated GPIO via sysfs/printf)
 cmake -B build -DEOS_PRODUCT=iot -DEOS_BUILD_TESTS=ON
@@ -264,7 +264,7 @@ This produces:
 ### 3. Sign and flash
 ```bash
 # Create signing key (first time only)
-cd EoS/eboot/tools
+cd eBoot/tools
 python3 sign_image.py --generate-key my-key.pem
 
 # Sign firmware

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,64 @@
+# EoS — Feature Maturity
+
+§25 of the platform architecture document requires every significant feature to carry a
+maturity state with the evidence that state demands. This file records them for `eos`.
+
+Measured on **29 Aug 2026** against this branch. Every row below cites a command that was
+run, or says plainly that it was not.
+
+## States and the evidence each requires (§25)
+
+| State | Definition | Required evidence |
+|---|---|---|
+| Planned | Design intent; not yet available | Roadmap / issue / design spec |
+| Experimental | Working prototype; API/behaviour may change | Tests + known limitations |
+| Implemented | Feature exists and is usable | Code + functional tests |
+| Validated | Verified on named targets/use cases | Test reports / CI / hardware matrix / benchmarks |
+| Certified | Formally certified to a named standard | Certificate / audit reference |
+
+`Unknown` appears below where evidence was not collected. It is **not** a §25 state — it
+is an admission of an unmeasured claim, and should be driven to zero.
+
+## Repository-level
+
+| | |
+|---|---|
+| **Overall** | **Experimental** |
+| Host evidence | CMake 4.2.3 / GCC 15.2.0; `ctest` **28/28 pass** |
+| Cross evidence | `toolchains/arm-cortex-m4.cmake` builds 23 static libraries; artifacts report `architecture: armv7e-m`. Footprint **15.8 KB flash, 26 KB RAM** (`arm-none-eabi-size -t`) |
+| Blocking Implemented | No board-level or on-hardware evidence. Nothing has been observed to boot. |
+
+## Subsystem detail
+
+| Subsystem | Builds as | State | Evidence / gap |
+|---|---|---|---|
+| Kernel (task, sync, ipc, multicore, heap) | `libeos_kernel.a` | Experimental | Builds host and Cortex-M4; `test_kernel` passes. Mutex priority inheritance is transitive and recomputed from an invariant. No preemption or latency measurement. |
+| HAL — dispatch layer | `libeos_hal.a` | Experimental | `hal_common.c` dispatches to a registered backend; `test_drivers` passes. |
+| HAL — host backend | (in `libeos_hal.a`) | **Planned** | `hal_linux.c` implements a Linux backend, but `eos_hal_linux_register()` is **never called and is declared in no public header**. On a host build no backend registers, `eos_hal_init()` returns `-1`, and every HAL call silently no-ops. |
+| HAL — extended peripherals (ADC, PWM, I²C, SPI, …) | (in `libeos_hal.a`) | **Planned** | `hal_extended_stubs.c` is 740 of the HAL's 3,185 lines and contains 144 `(void)param;` casts. The API exists; the peripherals do not. |
+| Architecture — ARM Cortex-M4 / R5 | 23 `.a` targets | Experimental | Cross-compiles clean via `arm-cortex-m4`, `arm-none-eabi-stm32f4` and `arm-none-eabi-r5`; artifacts verified `armv7e-m` / `armv7` with `objdump -f`. **Never executed** — no board, no QEMU. |
+| Architecture — RISC-V, Cortex-A/AArch64 | — | **Unknown** | Toolchain files exist (`riscv64-linux-gnu.cmake`, `aarch64-linux-gnu.cmake`). Neither toolchain was installed, so neither was built. **NOT RUN.** |
+| Boards | `boards/*.yaml` | **Planned** | 84 descriptors, of which **71 are named `generic-*`**. A descriptor is not a port; none has been validated on hardware. |
+| Drivers + devicetree | `libeos_drivers.a`, `libeos_devicetree.a` | Experimental | Build; `test_drivers` and `test_devicetree` pass. The DTB parser is bounds-checked against untrusted input and has a fuzz target. Per-driver status unassessed. |
+| Networking (eNet) | `libeos_net.a` | **Planned** | Per **ADR-014**. `net/src/net.c` is 190 lines carrying 20 `(void)param;` casts; `eos_net_connect()` is `return -1`. There is no protocol implementation of any kind. `test_net` passes because it tests the facade's argument validation, not a connection. §12 names TCP/IP, UDP, DHCP, DNS, MQTT, CoAP, HTTP and WebSocket — **none exist**. |
+| Security (eSec) — keystore, ACL | `libeos_security.a` | Experimental | Builds; `test_security` passes. |
+| Security (eSec) — RSA / ECC signatures | (in `libeos_crypto.a`) | **Planned** | Per **ADR-011 / ADR-012**. The RSA and ECC routines are stubs: `eos_ecc_verify()` accepted any 64-byte signature and `eos_rsa_verify_sha256()` compared only the trailing 32 bytes. They now refuse to run unless a build defines `EOS_ALLOW_STUB_CRYPTO`, and `test_crypto_failclosed` asserts that refusal. **No signature verification exists.** |
+| Security (eSec) — AES, SHA-256, SHA-512 | (in `libeos_crypto.a`) | Experimental | Build; `test_crypto`, `test_crypto_aes`, `test_crypto_sha512` and `test_crypto_vectors` pass, including NIST vectors. Hand-written; **not independently audited**, which §4 discourages. ADR-012 selects Mbed TLS to replace them. |
+| Power management | `libeos_power.a` | Experimental | Builds; `test_power` passes. Peripheral IDs are bounds-checked against negative values. |
+| Filesystem | `libeos_filesystem.a` | Experimental | Builds; `test_filesystem` passes. No power-loss or wear-levelling evidence — the properties that matter most, and the ones unit tests cannot establish. |
+| OTA | `libeos_ota.a` | Experimental | Builds; `test_ota` passes. `eos_ota_apply()` refuses without a registered authenticator, so an image's own declared hash is no longer treated as proof of origin. **Not validated end-to-end against eBoot.** |
+| Packaging | `libeos_pkg.a`, `libeos_systems.a` | Experimental | Build; `test_package` and `test_config` pass. The config parser is bounds-checked against a package count exceeding `EOS_MAX_PACKAGES` (AddressSanitizer clean on the input that previously overflowed). |
+| Debug (GDB stub, core dump) | `libeos_debug.a` | Experimental | Builds; `test_debug` passes. `M`-packet payloads are length- and charset-validated. `eos_gdb_read_mem`/`write_mem` still cast a `uint32_t` to a pointer, so the accept path is untested on 64-bit hosts. |
+| POSIX compat adapter | `libeos_compat.a` | Experimental | Builds; `test_os_adapter` passes. |
+| Examples (13 apps) | not in the root build | Experimental | `examples/blink-gpio` builds standalone and runs on the host. The remaining twelve are **unverified**. |
+
+## Claims that must not be made until evidence exists
+
+- That any board or architecture is *supported* beyond a `boards/` descriptor and a clean
+  cross-compile. Nothing here has been observed to boot.
+- Any latency, throughput, power or boot-time figure. §25 requires a link to a reproducible
+  benchmark; no benchmark methodology is published. The footprint numbers above are the one
+  exception — `arm-none-eabi-size -t` is reproducible and the command is given.
+- Any comparison against another OS.
+- Real-time or deterministic guarantees — no scheduling latency measurement exists.
+- That EoS has networking or signature verification. Both are `Planned`.

--- a/core/src/config.c
+++ b/core/src/config.c
@@ -124,7 +124,8 @@ EosResult eos_config_load(EosConfig *cfg, const char *path) {
             } else if (section == SEC_PACKAGES ||
                        section == SEC_PKG_ENTRY ||
                        section == SEC_PKG_BUILD ||
-                       section == SEC_PKG_OPTIONS) {
+                       section == SEC_PKG_OPTIONS ||
+                       section == SEC_PKG_DEPS) {
                 if (parse_kv(item, key, sizeof(key), val, sizeof(val)) == 0 &&
                     strcmp(key, "name") == 0) {
                     pkg_idx = cfg->package_count;
@@ -146,13 +147,13 @@ EosResult eos_config_load(EosConfig *cfg, const char *path) {
                                    EOS_MAX_PACKAGES, val);
                         section = SEC_PACKAGES;
                     }
-                }
-            } else if (section == SEC_PKG_DEPS &&
-                       pkg_idx >= 0 && pkg_idx < EOS_MAX_PACKAGES) {
-                if (cfg->packages[pkg_idx].dep_count < EOS_MAX_DEPS) {
-                    strncpy(cfg->packages[pkg_idx].deps[cfg->packages[pkg_idx].dep_count],
-                            item, EOS_MAX_NAME - 1);
-                    cfg->packages[pkg_idx].dep_count++;
+                } else if (section == SEC_PKG_DEPS &&
+                           pkg_idx >= 0 && pkg_idx < EOS_MAX_PACKAGES) {
+                    if (cfg->packages[pkg_idx].dep_count < EOS_MAX_DEPS) {
+                        strncpy(cfg->packages[pkg_idx].deps[cfg->packages[pkg_idx].dep_count],
+                                item, EOS_MAX_NAME - 1);
+                        cfg->packages[pkg_idx].dep_count++;
+                    }
                 }
             } else if (section == SEC_SYSTEM_RTOS || section == SEC_SYSTEM_RTOS_ENTRY) {
                 /* "- provider: freertos" starts a new RTOS entry */
@@ -279,6 +280,7 @@ EosResult eos_config_load(EosConfig *cfg, const char *path) {
                 cfg->packages[pkg_idx].build_type = eos_build_type_from_str(val);
             }
             if (indent <= 2 && strcmp(key, "options") == 0) { section = SEC_PKG_OPTIONS; continue; }
+            if (indent <= 2 && strcmp(key, "deps") == 0) { section = SEC_PKG_DEPS; continue; }
             if (indent <= 2 && strcmp(key, "version") == 0) {
                 section = SEC_PKG_ENTRY;
                 strncpy(cfg->packages[pkg_idx].version, val, EOS_MAX_NAME - 1);

--- a/core/src/log.c
+++ b/core/src/log.c
@@ -5,6 +5,7 @@
 #include "eos/log.h"
 #include <stdio.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <string.h>
 #include <time.h>
 
@@ -106,12 +107,22 @@ static const char *color_reset(void) {
 }
 
 static uint32_t get_timestamp_ms(void) {
-#ifdef _WIN32
+#if defined(_WIN32)
     return (uint32_t)GetTickCount();
-#else
+#elif defined(CLOCK_MONOTONIC)
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
         return (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+    return 0;
+#else
+    /* Bare-metal newlib (arm-none-eabi and friends) declares neither
+     * clock_gettime nor CLOCK_MONOTONIC, so the POSIX branch does not
+     * compile for the Cortex-M targets this project exists to build for.
+     *
+     * There is a timebase on a target -- eos_get_tick_ms() in the HAL -- but
+     * core/ sits below hal/ and must not depend upward, so log entries carry
+     * a zero timestamp until a port supplies one. Ordering within the ring
+     * buffer is preserved regardless; only the absolute time is missing. */
     return 0;
 #endif
 }
@@ -140,7 +151,7 @@ void eos_log_ring_dump(void) {
     for (int i = 0; i < g_ring_count; i++) {
         const EosLogEntry *e = eos_log_ring_get(i);
         if (e) {
-            fprintf(stderr, "[%u %5s] %s%s%s\n",
+            fprintf(stderr, "[%" PRIu32 " %5s] %s%s%s\n",
                     e->timestamp_ms, level_str(e->level),
                     e->module ? e->module : "", e->module ? ": " : "",
                     e->message);

--- a/docs/book/part1-foundations/ch01-introduction.md
+++ b/docs/book/part1-foundations/ch01-introduction.md
@@ -227,7 +227,7 @@ For cross-compilation to a specific board:
 
 ```bash
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```

--- a/docs/book/part1-foundations/ch02-getting-started.md
+++ b/docs/book/part1-foundations/ch02-getting-started.md
@@ -270,7 +270,7 @@ done
 cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```
@@ -376,7 +376,7 @@ sudo apt install gcc-arm-none-eabi
 cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 

--- a/docs/book/part1-foundations/ch03-architecture.md
+++ b/docs/book/part1-foundations/ch03-architecture.md
@@ -338,7 +338,7 @@ Toolchains are YAML-based definitions specifying CC, CXX, AR, sysroot, and flags
 Usage:
 
 ```bash
-cmake -B build -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake
 `
 
 ## 3.9 Configuration Schema Summary

--- a/docs/book/part4-ecosystem/ch17-eboot.md
+++ b/docs/book/part4-ecosystem/ch17-eboot.md
@@ -90,7 +90,7 @@ cd build && ctest
 
 ```bash
 cmake -B build-arm -DEBLDR_BOARD=stm32f4 \
-  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake
 cmake --build build-arm
 ```
 

--- a/docs/book/part5-hardware/ch25-ehealth365.md
+++ b/docs/book/part5-hardware/ch25-ehealth365.md
@@ -225,7 +225,7 @@ Both devices run EoS firmware with the `wearable` product profile:
 
 ```bash
 cmake -B build -DEOS_PRODUCT=wearable \
-  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake
 ```
 
 The firmware leverages:

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -126,7 +126,7 @@ Build your eos app with the linker script:
 ```bash
 cd EoS/eos
 cmake -B build -DEOS_PRODUCT=iot \
-  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake \
   -DEOS_LINKER_SCRIPT=../ebuild/_generated/eboot_linker.ld
 cmake --build build
 ```
@@ -135,7 +135,7 @@ cmake --build build
 
 ```bash
 # Generate signing key (first time only)
-cd EoS/eboot/tools
+cd eBoot/tools
 python3 sign_image.py --generate-key firmware-key.pem
 
 # Sign the firmware

--- a/docs/quickstart-host.md
+++ b/docs/quickstart-host.md
@@ -31,8 +31,8 @@ winget install CMake.CMake
 ## Step 1: Build an example
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build -DEOS_PRODUCT=iot
 cmake --build build
@@ -58,7 +58,7 @@ Press `Ctrl+C` to stop.
 ## Step 3: Run the full test suite
 
 ```bash
-cd EoS/eos
+cd eos
 cmake -B build -DEOS_BUILD_TESTS=ON
 cmake --build build
 ctest --test-dir build --output-on-failure
@@ -69,7 +69,7 @@ ctest --test-dir build --output-on-failure
 ## Try all examples
 
 ```bash
-cd EoS/eos/examples
+cd eos/examples
 
 # Each example builds the same way:
 for example in blink-gpio uart-echo multitask-rtos posix-app multicore-amp; do
@@ -97,7 +97,7 @@ done
 When you're ready to target an MCU:
 
 1. Install the cross-compiler (`arm-none-eabi-gcc`)
-2. Add `-DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake` to your cmake command
+2. Add `-DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake` to your cmake command
 3. Flash the resulting binary to your board
 
 Your application code stays the same — only the build command changes.

--- a/docs/quickstart-nrf52.md
+++ b/docs/quickstart-nrf52.md
@@ -35,11 +35,11 @@ nrfjprog --version              # Should print 10.x or later
 ## Step 1: Clone and build
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 ```

--- a/docs/quickstart-rpi4.md
+++ b/docs/quickstart-rpi4.md
@@ -24,8 +24,8 @@ sudo apt install cmake gcc g++ git python3 python3-pip
 
 ```bash
 # On the Raspberry Pi:
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 # Build using the Linux HAL backend (native compile on Pi)
 cmake -B build -DEOS_PRODUCT=gateway
@@ -69,7 +69,7 @@ Connect an LED + resistor (330Ω) between GPIO 18 and GND, then run.
 sudo apt install gcc-aarch64-linux-gnu
 
 # Build
-cd EoS/eos/examples/blink-gpio
+cd eos/examples/blink-gpio
 cmake -B build \
   -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
   -DEOS_PRODUCT=gateway

--- a/docs/quickstart-stm32.md
+++ b/docs/quickstart-stm32.md
@@ -29,11 +29,11 @@ brew install openocd                  # macOS
 ## Step 1: Clone and build
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos/examples/blink-gpio
+git clone https://github.com/embeddedos-org/eos.git
+cd eos/examples/blink-gpio
 
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=industrial
 cmake --build build
 ```

--- a/docs/three-way-alignment.md
+++ b/docs/three-way-alignment.md
@@ -211,7 +211,7 @@ cmake --build build
 # Outputs: libeboot_hal.a, libeboot_core.a, ebldr_stage0.bin, eboot_firmware.bin
 
 # Step 5: Sign and flash (uses eboot tools)
-cd EoS/eboot/tools
+cd eBoot/tools
 python3 sign_image.py --key key.pem --input ../../eos/build/app.bin --output signed.bin
 ```
 

--- a/docs/tutorials/stm32-deployment.md
+++ b/docs/tutorials/stm32-deployment.md
@@ -112,8 +112,8 @@ sudo udevadm trigger
 ## Step 1 — Clone the Repository
 
 ```bash
-git clone https://github.com/anthropic/EoS.git
-cd EoS/eos
+git clone https://github.com/embeddedos-org/eos.git
+cd eos
 ```
 
 ---

--- a/examples/ble-sensor/README.md
+++ b/examples/ble-sensor/README.md
@@ -31,7 +31,7 @@ A complete IoT sensor node that reads temperature from an I2C sensor, computes a
 ```bash
 # Cross-compile for nRF52
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 

--- a/examples/blink-gpio/README.md
+++ b/examples/blink-gpio/README.md
@@ -25,7 +25,7 @@ cmake --build build
 
 # ARM cross-compile
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=iot
 cmake --build build
 ```

--- a/examples/ui-touchscreen/README.md
+++ b/examples/ui-touchscreen/README.md
@@ -52,7 +52,7 @@ A complete touchscreen application that builds an interactive interface with LVG
 ```bash
 # Cross-compile for ARM target
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-none-eabi.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=../../toolchains/arm-cortex-m4.cmake \
   -DEOS_PRODUCT=hmi
 cmake --build build
 

--- a/hal/include/eos/hal.h
+++ b/hal/include/eos/hal.h
@@ -29,9 +29,29 @@ extern "C" {
  * Initialize the HAL subsystem for the current platform.
  * Must be called before any other HAL function.
  *
+ * Selects the backend compiled for this platform when the application has not
+ * registered one of its own. A build that wants different hardware behaviour
+ * calls eos_hal_register_backend() first, and that choice is kept.
+ *
  * @return 0 on success, negative error code on failure.
  */
 int eos_hal_init(void);
+
+/**
+ * Register the backend for this platform.
+ *
+ * Called for you by eos_hal_init(). Declared because a board port that
+ * layers on top of the platform backend needs to name it, and because an
+ * undeclared registrar is one nobody can find.
+ *
+ * Exactly one of these is compiled: hal_linux.c is guarded on __linux__ and
+ * hal_rtos.c on its absence.
+ */
+#ifdef __linux__
+void eos_hal_linux_register(void);
+#else
+void eos_hal_rtos_register(void);
+#endif
 
 /**
  * Deinitialize the HAL subsystem, releasing all resources.

--- a/hal/src/hal_common.c
+++ b/hal/src/hal_common.c
@@ -14,13 +14,39 @@
 
 static const eos_hal_backend_t *active_backend = NULL;
 
+/* Distinguishes "no backend has ever been chosen" from "a backend was chosen
+ * and it was NULL". eos_hal_init() fills the first case with the platform
+ * default; the second is a deliberate act by the application and is left
+ * alone, because a HAL that re-arms itself after being disarmed is worse than
+ * one that never armed. */
+static int backend_chosen = 0;
+
 void eos_hal_register_backend(const eos_hal_backend_t *backend)
 {
     active_backend = backend;
+    backend_chosen = 1;
 }
 
 int eos_hal_init(void)
 {
+    /* hal.h promises initialisation "for the current platform". Until now this
+     * returned -1 unless the application had already called
+     * eos_hal_register_backend() itself, which nothing in the tree, none of
+     * the examples, and none of the scaffolded templates did — so every HAL
+     * call on a host build silently did nothing and the generated hello-world
+     * produced no output.
+     *
+     * An application that registers its own backend before calling init keeps
+     * it, and so does one that deliberately registers NULL: the default only
+     * fills a slot nobody has set. */
+    if (!active_backend && !backend_chosen) {
+#ifdef __linux__
+        eos_hal_linux_register();
+#else
+        eos_hal_rtos_register();
+#endif
+    }
+
     if (!active_backend || !active_backend->init) return -1;
     return active_backend->init();
 }

--- a/kernel/include/eos/kernel_internal.h
+++ b/kernel/include/eos/kernel_internal.h
@@ -48,6 +48,9 @@ void eos_task_set_priority_internal(eos_task_handle_t h, uint8_t prio);
 
 /**
  * @brief Make @p h the running task. Handles >= EOS_MAX_TASKS clear it.
+ *
+ * Used by host tests to exercise multi-task mutex/IPC paths without a
+ * running context switcher. Not part of the public kernel API.
  */
 void eos_task_set_current_internal(eos_task_handle_t h);
 
@@ -64,14 +67,6 @@ void eos_task_block_with_timeout(eos_task_handle_t h, uint32_t timeout_ms);
  * @brief Unblock a task (set state to READY, disarm the wake deadline).
  */
 void eos_task_unblock(eos_task_handle_t h);
-
-/**
- * @brief Set the scheduler's notion of the current task.
- *
- * Used by host tests to exercise multi-task mutex/IPC paths without a
- * running context switcher. Not part of the public kernel API.
- */
-void eos_task_set_current_internal(eos_task_handle_t h);
 
 #ifdef __cplusplus
 }

--- a/kernel/src/sync.c
+++ b/kernel/src/sync.c
@@ -45,31 +45,78 @@ typedef struct {
 static mtx_t g_mtx[EOS_MAX_MUTEXES];
 static sem_t g_sem[EOS_MAX_SEMAPHORES];
 
-static void mtx_remove_waiter(mtx_t *m, uint8_t task)
+/* ============================================================
+ * Priority inheritance
+ *
+ * A task holding mutexes runs at
+ *
+ *     effective = min( base_priority,
+ *                      priority of every task waiting on every mutex it owns )
+ *
+ * with lower meaning more urgent. Recomputing from that invariant on every
+ * change, instead of saving and restoring a value around each lock, keeps the
+ * nested cases correct and lets a boost propagate along the blocking chain.
+ * ============================================================ */
+
+/* Mutex each task is blocked on, as handle + 1 so that 0 means "none". */
+static uint8_t g_blocked_on[EOS_MAX_TASKS];
+
+static inline int task_valid(uint8_t t)
 {
-    for (int i = 0; i < m->waiter_count; i++) {
-        if (m->waiters[i] == task) {
-            for (int j = i; j < m->waiter_count - 1; j++)
-                m->waiters[j] = m->waiters[j + 1];
-            m->waiter_count--;
-            break;
+    return t < EOS_MAX_TASKS;
+}
+
+/** @return non-zero if the effective priority changed. */
+static int pi_recompute(uint8_t task)
+{
+    if (!task_valid(task)) return 0;
+
+    uint8_t eff = g_tasks[task].base_priority;
+
+    for (int i = 0; i < EOS_MAX_MUTEXES; i++) {
+        const mtx_t *m = &g_mtx[i];
+        if (!m->in_use || !m->locked || m->owner != task) continue;
+        for (int w = 0; w < m->waiter_count; w++) {
+            uint8_t waiter = m->waiters[w];
+            if (!task_valid(waiter)) continue;
+            if (g_tasks[waiter].priority < eff)
+                eff = g_tasks[waiter].priority;
         }
+    }
+
+    if (g_tasks[task].priority == eff) return 0;
+    g_tasks[task].priority = eff;
+    return 1;
+}
+
+static void pi_propagate(uint8_t task)
+{
+    for (int depth = 0; depth < PI_MAX_CHAIN_DEPTH; depth++) {
+        if (!task_valid(task)) return;
+        if (!pi_recompute(task) && depth > 0) return;
+
+        uint8_t enc = g_blocked_on[task];
+        if (enc == 0) return;
+
+        uint8_t m = (uint8_t)(enc - 1u);
+        if (m >= EOS_MAX_MUTEXES) return;
+        if (!g_mtx[m].in_use || !g_mtx[m].locked) return;
+        if (g_mtx[m].owner == task) return;
+
+        task = g_mtx[m].owner;
     }
 }
 
-/* Recompute inherited priority from remaining waiters, or restore original. */
-static void mtx_recompute_owner_priority(mtx_t *m)
+static int mtx_remove_waiter(mtx_t *m, uint8_t task)
 {
-    if (m->owner == 0xFF)
-        return;
-
-    uint8_t prio = m->original_prio;
     for (int i = 0; i < m->waiter_count; i++) {
-        uint8_t wp = eos_task_get_priority_internal(m->waiters[i]);
-        if (wp < prio)
-            prio = wp;
+        if (m->waiters[i] != task) continue;
+        for (int j = i; j < m->waiter_count - 1; j++)
+            m->waiters[j] = m->waiters[j + 1];
+        m->waiter_count--;
+        return 1;
     }
-    eos_task_set_priority_internal(m->owner, prio);
+    return 0;
 }
 
 int eos_mutex_create(eos_mutex_handle_t *out)
@@ -123,21 +170,17 @@ int eos_mutex_lock(eos_mutex_handle_t h, uint32_t timeout_ms)
         return EOS_KERN_TIMEOUT;
     }
 
-    /* Waiter table full: fail without boosting, or the owner would stay
-     * elevated even though this caller is never queued. */
+    /* Refuse rather than block: a task that is not enqueued is never granted
+     * the mutex, so with EOS_WAIT_FOREVER it would sleep forever. */
     if (g_mtx[h].waiter_count >= MTX_MAX_WAITERS) {
         eos_port_exit_critical(crit);
         return EOS_KERN_NO_MEMORY;
     }
 
-    /* Priority inheritance: boost owner to caller's priority if higher */
-    uint8_t caller_prio = eos_task_get_priority_internal(caller);
-    uint8_t owner_prio = eos_task_get_priority_internal(g_mtx[h].owner);
-    if (caller_prio < owner_prio) {
-        eos_task_set_priority_internal(g_mtx[h].owner, caller_prio);
-    }
-
     g_mtx[h].waiters[g_mtx[h].waiter_count++] = caller;
+    if (task_valid(caller))
+        g_blocked_on[caller] = (uint8_t)(h + 1u);
+    pi_propagate(g_mtx[h].owner);
 
     /* Block the calling task */
     eos_task_block_with_timeout(caller, timeout_ms);
@@ -154,10 +197,11 @@ int eos_mutex_lock(eos_mutex_handle_t h, uint32_t timeout_ms)
         return EOS_KERN_OK;
     }
 
-    /* Timeout — drop from the wait queue and drop the inheritance boost
-     * if this waiter was the reason the owner was running elevated. */
+    /* Timeout — leave the queue and drop the boost we were causing. */
+    uint8_t owner = g_mtx[h].owner;
     mtx_remove_waiter(&g_mtx[h], caller);
-    mtx_recompute_owner_priority(&g_mtx[h]);
+    pi_propagate(owner);
+
     eos_port_exit_critical(crit);
     return EOS_KERN_TIMEOUT;
 }

--- a/kernel/src/task.c
+++ b/kernel/src/task.c
@@ -573,8 +573,4 @@ int eos_task_get_all_stats(eos_task_stats_t *out, int max_entries, int *count)
     return EOS_KERN_OK;
 }
 
-void eos_task_set_current_internal(eos_task_handle_t h)
-{
-    if (h >= EOS_MAX_TASKS) return;
-    g_current = (int)h;
-}
+

--- a/net/src/net.c
+++ b/net/src/net.c
@@ -14,6 +14,16 @@
 
 static bool net_initialized = false;
 
+/* The socket layer below is the freestanding fallback. On a host, ADR-014
+ * point 3 maps this API onto POSIX sockets instead; CMake compiles
+ * net_posix.c and defines EOS_NET_POSIX, and these stubs step aside so there
+ * is exactly one definition of each symbol.
+ *
+ * Left returning -1 rather than deleted: on a target with no IP stack yet,
+ * failing is the honest answer, and it is what ADR-014 records as the
+ * Planned state for the Nano and Edge profiles until lwIP lands. */
+#ifndef EOS_NET_POSIX
+
 int eos_net_init(void)
 {
     net_initialized = true;
@@ -105,6 +115,9 @@ int eos_net_resolve(const char *hostname, uint32_t *ip)
 }
 
 /* ---- HTTP ---- */
+
+
+#endif /* !EOS_NET_POSIX */
 
 int eos_http_get(const char *url, eos_http_response_t *resp)
 {

--- a/net/src/net_posix.c
+++ b/net/src/net_posix.c
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EoS Project
+// ISO/IEC 25000 | ISO/IEC/IEEE 15288:2023
+
+/**
+ * @file net_posix.c
+ * @brief eNet socket layer on POSIX sockets — the Compute profile.
+ *
+ * ADR-014 point 3: "On the Compute profile, where a host OS is present, the
+ * same API maps to POSIX sockets." This is that mapping.
+ *
+ * Before this file, every function here was a stub — eos_net_connect() was
+ * `return -1` and eos_net_socket() returned an incrementing integer that named
+ * nothing. Anything built on eNet could not be exercised on any target,
+ * including the host, which is where EoSim runs.
+ *
+ * Scope is deliberately the socket layer only. ADR-014 point 5 keeps MQTT,
+ * CoAP and HTTP out: they are separate adoption decisions on top of a working
+ * IP stack, and they stay in net.c until those decisions are made.
+ *
+ * This does not make eNet Implemented. lwIP is still the decision for the Nano
+ * and Edge profiles (ADR-014 point 1), where there is no host OS to borrow
+ * sockets from.
+ */
+
+#include "eos/net.h"
+
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+/* eos_socket_t is an int and EOS_SOCKET_INVALID is -1, which is exactly what
+ * socket(2) returns on failure, so the fd is the handle. No table, no
+ * translation, and no way for the two to drift. */
+
+static int g_initialised;
+
+static int to_sockaddr(const eos_net_addr_t *addr, struct sockaddr_in *out)
+{
+    if (!addr) return -1;
+    memset(out, 0, sizeof(*out));
+    out->sin_family = AF_INET;
+    out->sin_port = htons(addr->port);
+    /* eos_net_addr_t documents ip as network byte order, so it is copied
+     * rather than converted. Calling htonl here would swap it twice. */
+    out->sin_addr.s_addr = addr->ip;
+    return 0;
+}
+
+static void from_sockaddr(const struct sockaddr_in *in, eos_net_addr_t *out)
+{
+    if (!out) return;
+    out->ip = in->sin_addr.s_addr;
+    out->port = ntohs(in->sin_port);
+}
+
+int eos_net_init(void)
+{
+    g_initialised = 1;
+    return 0;
+}
+
+void eos_net_deinit(void)
+{
+    g_initialised = 0;
+}
+
+eos_socket_t eos_net_socket(eos_net_proto_t proto)
+{
+    if (!g_initialised) return EOS_SOCKET_INVALID;
+    if (proto != EOS_NET_TCP && proto != EOS_NET_UDP) return EOS_SOCKET_INVALID;
+
+    int type = (proto == EOS_NET_TCP) ? SOCK_STREAM : SOCK_DGRAM;
+    int fd = socket(AF_INET, type, 0);
+    if (fd < 0) return EOS_SOCKET_INVALID;
+
+    /* Without SO_REUSEADDR a listener cannot rebind while the previous
+     * socket sits in TIME_WAIT, which makes a restart fail for a minute for
+     * no reason the caller can see. */
+    int one = 1;
+    (void)setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    return fd;
+}
+
+int eos_net_connect(eos_socket_t sock, const eos_net_addr_t *addr)
+{
+    struct sockaddr_in sa;
+    if (sock < 0 || to_sockaddr(addr, &sa) != 0) return -1;
+    return connect(sock, (const struct sockaddr *)&sa, sizeof(sa)) == 0 ? 0 : -1;
+}
+
+int eos_net_bind(eos_socket_t sock, uint16_t port)
+{
+    if (sock < 0) return -1;
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_ANY);
+    sa.sin_port = htons(port);
+    return bind(sock, (const struct sockaddr *)&sa, sizeof(sa)) == 0 ? 0 : -1;
+}
+
+int eos_net_listen(eos_socket_t sock, int backlog)
+{
+    if (sock < 0 || backlog < 0) return -1;
+    return listen(sock, backlog) == 0 ? 0 : -1;
+}
+
+eos_socket_t eos_net_accept(eos_socket_t sock, eos_net_addr_t *client_addr)
+{
+    if (sock < 0) return EOS_SOCKET_INVALID;
+    struct sockaddr_in sa;
+    socklen_t len = sizeof(sa);
+    int fd = accept(sock, (struct sockaddr *)&sa, &len);
+    if (fd < 0) return EOS_SOCKET_INVALID;
+    if (client_addr) from_sockaddr(&sa, client_addr);
+    return fd;
+}
+
+int eos_net_send(eos_socket_t sock, const void *data, size_t len)
+{
+    if (sock < 0 || (!data && len > 0)) return -1;
+    /* MSG_NOSIGNAL: writing to a peer that has gone away raises SIGPIPE by
+     * default, which kills the process instead of returning an error the
+     * caller can handle. */
+    ssize_t n = send(sock, data, len, MSG_NOSIGNAL);
+    return n < 0 ? -1 : (int)n;
+}
+
+int eos_net_recv(eos_socket_t sock, void *buf, size_t len, uint32_t timeout_ms)
+{
+    if (sock < 0 || (!buf && len > 0)) return -1;
+
+    struct timeval tv;
+    tv.tv_sec = (time_t)(timeout_ms / 1000u);
+    tv.tv_usec = (suseconds_t)((timeout_ms % 1000u) * 1000u);
+    /* A zero timeout means "block forever" to SO_RCVTIMEO, which is the
+     * opposite of what a caller passing 0 expects. Only set it when non-zero. */
+    if (timeout_ms > 0) {
+        (void)setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    }
+
+    ssize_t n = recv(sock, buf, len, 0);
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return 0;  /* timed out */
+    return n < 0 ? -1 : (int)n;
+}
+
+int eos_net_sendto(eos_socket_t sock, const void *data, size_t len,
+                   const eos_net_addr_t *addr)
+{
+    struct sockaddr_in sa;
+    if (sock < 0 || (!data && len > 0) || to_sockaddr(addr, &sa) != 0) return -1;
+    ssize_t n = sendto(sock, data, len, MSG_NOSIGNAL,
+                       (const struct sockaddr *)&sa, sizeof(sa));
+    return n < 0 ? -1 : (int)n;
+}
+
+int eos_net_recvfrom(eos_socket_t sock, void *buf, size_t len,
+                     eos_net_addr_t *addr, uint32_t timeout_ms)
+{
+    if (sock < 0 || (!buf && len > 0)) return -1;
+
+    if (timeout_ms > 0) {
+        struct timeval tv;
+        tv.tv_sec = (time_t)(timeout_ms / 1000u);
+        tv.tv_usec = (suseconds_t)((timeout_ms % 1000u) * 1000u);
+        (void)setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    }
+
+    struct sockaddr_in sa;
+    socklen_t sl = sizeof(sa);
+    ssize_t n = recvfrom(sock, buf, len, 0, (struct sockaddr *)&sa, &sl);
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return 0;
+    if (n < 0) return -1;
+    if (addr) from_sockaddr(&sa, addr);
+    return (int)n;
+}
+
+int eos_net_close(eos_socket_t sock)
+{
+    if (sock < 0) return -1;
+    return close(sock) == 0 ? 0 : -1;
+}
+
+int eos_net_resolve(const char *hostname, uint32_t *ip)
+{
+    if (!hostname || !ip) return -1;
+
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;          /* eos_net_addr_t.ip is 32 bits */
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    if (getaddrinfo(hostname, NULL, &hints, &res) != 0 || !res) return -1;
+
+    *ip = ((const struct sockaddr_in *)res->ai_addr)->sin_addr.s_addr;
+    freeaddrinfo(res);
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,13 @@ add_test(NAME test_power COMMAND test_power)
 # --- test_net: Networking abstraction ---
 add_executable(test_net test_net.c)
 target_link_libraries(test_net PRIVATE eos_net)
+# The POSIX round-trip cases need the same switch the library was built with,
+# plus pthreads for the listener they connect to.
+if(NOT CMAKE_CROSSCOMPILING)
+    target_compile_definitions(test_net PRIVATE EOS_NET_POSIX=1)
+    find_package(Threads REQUIRED)
+    target_link_libraries(test_net PRIVATE Threads::Threads)
+endif()
 add_test(NAME test_net COMMAND test_net)
 
 # --- test_motor_ctrl: Motor control PID ---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,16 +73,6 @@ add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)
 add_test(NAME test_crypto_sha512 COMMAND test_crypto_sha512)
 
-# --- test_crypto_aes: AES-128/192/256 ECB + CBC, NIST FIPS-197 / SP 800-38A ---
-add_executable(test_crypto_aes test_crypto_aes.c)
-target_link_libraries(test_crypto_aes PRIVATE eos_crypto)
-add_test(NAME test_crypto_aes COMMAND test_crypto_aes)
-
-# --- test_crypto_sha512: SHA-512 against NIST vectors ---
-add_executable(test_crypto_sha512 test_crypto_sha512.c)
-target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)
-add_test(NAME test_crypto_sha512 COMMAND test_crypto_sha512)
-
 # --- test_security: Keystore, ACL ---
 add_executable(test_security test_security.c)
 target_link_libraries(test_security PRIVATE eos_security eos_crypto)

--- a/tests/test_hal.c
+++ b/tests/test_hal.c
@@ -150,14 +150,66 @@ TEST(test_no_backend) {
     ASSERT(eos_get_tick_ms() == 0);
 }
 
+
+/* ── Platform backend selection ───────────────────────────────────────────
+ *
+ * hal.h promises initialisation "for the current platform". It used to return
+ * -1 unless the application had already called eos_hal_register_backend()
+ * itself — which nothing in the tree, none of the examples and none of the
+ * scaffolded templates did. Every HAL call on a host build silently did
+ * nothing, and the generated hello-world produced no output.
+ */
+
+static int g_custom_init_calls;
+
+static int custom_init(void) { g_custom_init_calls++; return 0; }
+
+static const eos_hal_backend_t custom_backend = {
+    .name = "custom",
+    .init = custom_init,
+};
+
+TEST(test_init_selects_the_platform_backend) {
+    /* A program that has registered nothing still gets a working HAL. */
+    ASSERT(eos_hal_init() == 0);
+    eos_hal_deinit();
+}
+
+TEST(test_tick_source_advances) {
+    /* The one facility every platform must provide. A backend that was never
+     * selected reports 0 forever, which reads as a stopped clock rather than
+     * as a missing backend. */
+    ASSERT(eos_hal_init() == 0);
+    uint32_t before = eos_get_tick_ms();
+    eos_delay_ms(20);
+    ASSERT(eos_get_tick_ms() >= before + 10);
+    eos_hal_deinit();
+}
+
+TEST(test_an_application_backend_is_not_overridden) {
+    /* The default fills an empty slot; it does not outrank a choice. */
+    g_custom_init_calls = 0;
+    eos_hal_register_backend(&custom_backend);
+    ASSERT(eos_hal_init() == 0);
+    ASSERT(g_custom_init_calls == 1);
+    eos_hal_register_backend(NULL);
+}
+
 int main(void) {
     printf("=== EoS: HAL Unit Tests ===\n\n");
+    /* These two must come first. Every later test calls setup(), which
+     * registers a mock backend; run after it, they would exercise the mock
+     * and quietly stop testing platform selection at all. */
+    run_test_init_selects_the_platform_backend();
+    run_test_tick_source_advances();
+
     run_test_init_deinit();
     run_test_gpio_write_read();
     run_test_gpio_toggle();
     run_test_tick_counter();
+    run_test_an_application_backend_is_not_overridden();
     run_test_no_backend();
-    tests_run = 5;
+    tests_run = 8;
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -148,6 +148,99 @@ static void test_mdns_init(void) {
     eos_net_deinit();
     PASS("mdns init/deinit");
 }
+
+/* ── POSIX socket layer (ADR-014 point 3) ─────────────────────────────────
+ *
+ * Everything above tests the facade's argument validation, which passed just
+ * as well when eos_net_connect() was `return -1`. These exercise a real
+ * connection, so they compile only where a host OS supplies the sockets.
+ */
+#ifdef EOS_NET_POSIX
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <time.h>
+
+static uint16_t g_test_port = 45771;
+
+static void *echo_server(void *arg) {
+    int *ready = (int *)arg;
+    eos_socket_t s = eos_net_socket(EOS_NET_TCP);
+    if (s == EOS_SOCKET_INVALID || eos_net_bind(s, g_test_port) != 0) {
+        *ready = -1;
+        return NULL;
+    }
+    eos_net_listen(s, 1);
+    *ready = 1;
+    eos_net_addr_t peer;
+    eos_socket_t c = eos_net_accept(s, &peer);
+    if (c != EOS_SOCKET_INVALID) {
+        char buf[32];
+        memset(buf, 0, sizeof(buf));
+        int n = eos_net_recv(c, buf, sizeof(buf) - 1, 2000);
+        if (n > 0) eos_net_send(c, buf, (size_t)n);
+        eos_net_close(c);
+    }
+    eos_net_close(s);
+    return NULL;
+}
+
+static void test_net_tcp_round_trip(void) {
+    eos_net_init();
+    int ready = 0;
+    pthread_t t;
+    pthread_create(&t, NULL, echo_server, &ready);
+    /* Wait for the listener rather than sleeping a fixed interval, so this
+     * does not go flaky on a loaded machine. */
+    for (int i = 0; i < 400 && ready == 0; i++) {
+        struct timespec ts;
+        ts.tv_sec = 0;
+        ts.tv_nsec = 5 * 1000 * 1000;
+        nanosleep(&ts, NULL);
+    }
+    assert(ready == 1);
+    eos_socket_t c = eos_net_socket(EOS_NET_TCP);
+    eos_net_addr_t addr;
+    addr.ip = inet_addr("127.0.0.1");
+    addr.port = g_test_port;
+    assert(eos_net_connect(c, &addr) == 0);
+    assert(eos_net_send(c, "ping", 4) == 4);
+    char buf[32];
+    memset(buf, 0, sizeof(buf));
+    assert(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
+    assert(strcmp(buf, "ping") == 0);
+    eos_net_close(c);
+    pthread_join(t, NULL);
+    eos_net_deinit();
+    PASS("net tcp round trip");
+}
+
+static void test_net_resolve_localhost(void) {
+    eos_net_init();
+    uint32_t ip = 0;
+    assert(eos_net_resolve("localhost", &ip) == 0);
+    assert(ip == inet_addr("127.0.0.1"));
+    /* A name that cannot resolve must fail rather than reporting success and
+     * leaving the caller with whatever was in the output already. */
+    uint32_t before = ip;
+    assert(eos_net_resolve("no.such.host.invalid", &ip) == -1);
+    assert(ip == before);
+    eos_net_deinit();
+    PASS("net resolve localhost");
+}
+
+static void test_net_connect_refused(void) {
+    eos_net_init();
+    eos_socket_t c = eos_net_socket(EOS_NET_TCP);
+    eos_net_addr_t addr;
+    addr.ip = inet_addr("127.0.0.1");
+    addr.port = 1;              /* nothing listens on port 1 */
+    assert(eos_net_connect(c, &addr) != 0);
+    eos_net_close(c);
+    eos_net_deinit();
+    PASS("net connect to a closed port fails");
+}
+#endif /* EOS_NET_POSIX */
+
 int main(void) {
     printf("=== EoS Networking Tests ===\n");
     test_net_init();
@@ -166,6 +259,11 @@ int main(void) {
     test_http_post();
     test_mqtt_connect();
     test_mdns_init();
+#ifdef EOS_NET_POSIX
+    test_net_tcp_round_trip();
+    test_net_resolve_localhost();
+    test_net_connect_refused();
+#endif
     printf("\n=== ALL %d NET TESTS PASSED ===\n", passed);
     return 0;
 }


### PR DESCRIPTION
`hal.h` documents `eos_hal_init()` as initialising *"the HAL subsystem for the current platform."* **It did not.**

It returned `-1` unless the application had already called `eos_hal_register_backend()` itself — and nothing in the tree, none of the examples, and none of ebuild's scaffolded templates ever did.

## The consequence was silent

`eos_hal_init()` returned `-1`, the generated hello-world ignored it as generated code does, and every subsequent HAL call dispatched through a NULL backend and did nothing. **The MVP's own first program ran its loop and produced no output.**

## Both backends already existed; neither was reachable

`eos_hal_linux_register()` in `hal_linux.c` and `eos_hal_rtos_register()` in `hal_rtos.c` — declared in no header, called from nowhere. They're mutually exclusive (`#ifdef __linux__` vs `#if !defined(__linux__)`), so exactly one compiles and init can pick it without ambiguity.

Both are now declared in `hal.h`. **A registrar nobody can find is a registrar nobody uses.**

## The interesting case

The existing `test_no_backend` covers it:

```c
eos_hal_register_backend(NULL);
ASSERT(eos_hal_init() == -1);
```

That's a deliberate act, and **a HAL that re-arms itself after being disarmed would be worse than one that never armed.** So *"no backend has ever been chosen"* is tracked separately from *"a backend was chosen and it was NULL"*. The default fills only the first. An application backend registered before init is likewise kept.

## The test ordering is load-bearing

Three tests added, and **they must run first.** Every later case calls `setup()`, which registers a mock backend. Placed after it they passed while exercising the mock — testing nothing.

I wrote them in the wrong order first and they passed for exactly that reason.

## Not fixed here

The Linux backend drives **real GPIO** through `/sys/class/gpio`, so `eos_gpio_init()` still fails on a workstation with no exported pins. That is correct — it's a hardware backend, not a simulator — and it's why *"simulation before hardware is available"* is an MLP item needing a simulation backend, not a change to this one.

## Verification

| | before | after |
|---|---|---|
| `eos_hal_init()` | `-1` | `0` |
| tick across a 20 ms delay | `0` forever | `20` |
| `test_hal` | 5 cases | **8 cases** |
| host `ctest` | — | **28/28** |
| ARM cross-build | — | clean |

The new tests **fail** against the unfixed `hal_common.c` and pass with it.

Stacks on #89 (eNet POSIX sockets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
