### PR TITLE
docs: make the README's counts and claims match the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,32 @@ EoS is a multi-platform embedded OS framework written in pure C11. A single
 source tree provides a lightweight RTOS kernel, a hardware abstraction layer
 (HAL) with host (Linux) and bare-metal backends, a driver framework, and
 networking, power-management, and runtime-service layers. It targets Linux hosts
-and bare-metal MCUs through a HAL split, and carries descriptors for 83 boards
-and 40+ product profiles selected at configure time.
+and bare-metal MCUs through a HAL split, and carries descriptors for 84 boards
+and 48 product profiles selected at configure time. A descriptor is not a port:
+71 of the 84 are named `generic-*`, and none has been validated on hardware.
 
 EoS is the OS core of the **EmbeddedOS** ([embeddedos-org](https://github.com/embeddedos-org))
 ecosystem, alongside [eBoot](https://github.com/embeddedos-org/eBoot) (secure
 bootloader), [eAI](https://github.com/embeddedos-org/eAI) (on-device AI), and
 [eNI](https://github.com/embeddedos-org/eNI) (neural interface). Project version
 0.5.0.
+
+## Status
+
+Every subsystem carries a §25 maturity state in [`STATUS.md`](STATUS.md), with
+the evidence behind it. The repository as a whole is **Experimental**.
+
+Two things worth knowing before building on it:
+
+- **Networking is `Planned`.** `net/` is an API with a POSIX backend for host
+  builds. There is no IP stack for bare-metal targets; `eos_net_connect()`
+  returns `-1` there. lwIP is the recorded decision ([ADR-014](docs/adr/ADR-014-tcpip-via-lwip.md)).
+- **RSA and ECC signature verification is `Planned`.** Those routines are stubs
+  and refuse to run unless a build defines `EOS_ALLOW_STUB_CRYPTO`. AES,
+  SHA-256 and SHA-512 are implemented and pass NIST vectors.
+
+Nothing here has been observed to boot on hardware. No latency, throughput or
+power figure is published, because no reproducible benchmark exists to link to.
 
 ## What's inside
 
@@ -31,8 +49,8 @@ bootloader), [eAI](https://github.com/embeddedos-org/eAI) (on-device AI), and
 | `core/` | OS config, logging, layer plumbing |
 | `services/` | Runtime services: `crypto`, `security`, `os`, `linux`, `linux_ipc`, `gps`, `motor`, `ota`, `filesystem`, `sensor`, `ui`, `init`, and more |
 | `systems/` | Rootfs, image, and firmware assembly |
-| `boards/` | 83 board descriptor files (`boards/*.yaml`) plus linker scripts |
-| `products/` | ~40 product-profile headers selected by `EOS_PRODUCT` |
+| `boards/` | 84 board descriptor files (`boards/*.yaml`) plus linker scripts |
+| `products/` | 48 product-profile headers selected by `EOS_PRODUCT` |
 | `layers/` | `ai`, `bsp`, `core`, `distro`, `product`, `rtos` layer definitions |
 | `toolchains/`, `cmake/` | Cross-compile toolchain and helper CMake files |
 | `backends/`, `sim/`, `pkg/`, `debug/` | Backend abstraction, simulation, packaging, and debug (GDB stub, core dump) |
@@ -55,10 +73,27 @@ cmake --build build/host --parallel
 |--------|---------|---------|
 | `EOS_BUILD_TESTS` | `OFF` | Enable `ctest` and build `tests/` |
 | `EOS_PLATFORM` | `linux` | Target platform: `linux` \| `rtos` (selects the HAL backend) |
-| `EOS_PRODUCT` | *(empty)* | One of ~40 product profiles; empty = full build |
+| `EOS_PRODUCT` | *(empty)* | One of 48 product profiles; empty = full build |
 
 `EOS_PLATFORM` resolves to the host HAL when set to `linux` or when not
 cross-compiling.
+
+### Cross-compiling
+
+```bash
+cmake -B build/arm -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake \
+  -DEOS_BUILD_TESTS=OFF
+cmake --build build/arm --parallel
+```
+
+`toolchains/` carries six toolchain files. Three are exercised on every
+release: `arm-cortex-m4`, `arm-none-eabi-stm32f4` and `arm-none-eabi-r5`, which
+produce `armv7e-m` and `armv7` objects. The RISC-V and AArch64 files exist but
+are unverified — see [`STATUS.md`](STATUS.md).
+
+Footprint of the full library set on Cortex-M4, via `arm-none-eabi-size -t`:
+**15.8 KB flash, 26.0 KB RAM**.
 
 ## Test
 


### PR DESCRIPTION
Everything the README documents was re-run against the tree. **The build and test commands work verbatim** — including the note that `EOS_PRODUCT=vbox_test` is required for the OTA, sensor, motor and power cases, which is correct and worth confirming rather than assuming.

## Stale counts

| claim | actual |
|---|---|
| 83 boards | **84** |
| ~40 product profiles | **48** |

## The board line needed more than a number

> *"carries descriptors for 83 boards"*

That reads as 83 supported boards. **71 of the 84 are named `generic-*`.** The sentence now says a descriptor is not a port and that none has been validated on hardware — which is what `STATUS.md` records.

## Added a Status section

The README had **no maturity signal at all**. A reader had no way to learn the two things that most change how they'd use this:

- **Networking is `Planned`.** `net/` is an API with a POSIX backend for host builds; there's no IP stack for bare-metal targets and `eos_net_connect()` returns `-1` there. ADR-014 records lwIP as the decision.
- **RSA/ECC signature verification is `Planned`.** Those routines are stubs and refuse to run without `EOS_ALLOW_STUB_CRYPTO`. AES, SHA-256 and SHA-512 *are* implemented and pass NIST vectors — the distinction matters.

It also states plainly that nothing has been observed to boot on hardware, and that no latency/throughput/power figure is published because no reproducible benchmark exists to link to. §25 requires the link, and **the absence of numbers is easier to misread than their presence.**

## Added cross-compiling

It works and was undocumented. Three of the six toolchain files build clean and produce `armv7e-m` and `armv7` objects; the full library set measures **15.8 KB flash / 26.0 KB RAM** on Cortex-M4. RISC-V and AArch64 are named as *unverified* rather than listed alongside the three that work.

## Verification

Every count re-counted from the tree. Both documented test commands run — `ctest` **30/30**, `run_all_tests.py` **10 passed**. The new cross-compile block run verbatim: **0 build errors**.

Depends on **#88** for `STATUS.md`, which this links twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
