### PR TITLE
fix(net): keep net_posix.c an empty TU when eNet is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,39 @@ jobs:
             --cov-fail-under=0
         continue-on-error: false
 
+  # ── Default configuration ─────────────────────────────────────────────────
+  # The `test` job above builds with -DEOS_BUILD_TESTS=ON -DEOS_PRODUCT=vbox_test,
+  # and both of those turn optional features on. Nothing in CI built the
+  # configuration a new user actually gets: the README quick start, which sets
+  # neither. That gap let a translation unit that only compiles under
+  # EOS_ENABLE_NET reach master. This job is that missing coverage — it is the
+  # README's own two commands, plus two product profiles that leave eNet off.
+  default-config:
+    name: Default configuration (no tests, no product)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends cmake ninja-build
+
+      - name: Build the README quick start
+        run: |
+          cmake -B build/host -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          cmake --build build/host --parallel $(nproc)
+
+      - name: Build product profiles that leave eNet off
+        run: |
+          for product in medical aerospace; do
+            cmake -B "build/$product" -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+              -DEOS_PRODUCT="$product"
+            cmake --build "build/$product" --parallel $(nproc)
+          done
+
   # ── Cross-compile ARM Cortex-M4 ───────────────────────────────────────────
   build-arm:
     name: Cross-compile ARM Cortex-M4

--- a/net/src/net_posix.c
+++ b/net/src/net_posix.c
@@ -25,6 +25,14 @@
 
 #include "eos/net.h"
 
+/* net.h declares eos_socket_t, eos_net_addr_t and eos_net_proto_t only under
+ * EOS_ENABLE_NET, and eos_config.h defaults that to 0. CMake adds this file to
+ * eos_net on every non-cross build regardless of the feature flag, so without
+ * this guard the translation unit fails to compile whenever eNet is disabled —
+ * which is the default, and what the README's own quick start configures.
+ * net.c is bracketed the same way; this is the sibling that was missing it. */
+#if EOS_ENABLE_NET
+
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -203,3 +211,5 @@ int eos_net_resolve(const char *hostname, uint32_t *ip)
     freeaddrinfo(res);
     return 0;
 }
+
+#endif /* EOS_ENABLE_NET */


### PR DESCRIPTION
## Summary

`net/src/net_posix.c` uses eNet types at file scope without an `#if EOS_ENABLE_NET` guard, while `net/include/eos/net.h` declares those types only when `EOS_ENABLE_NET` is enabled.

Because `EOS_ENABLE_NET` defaults to `0` and CMake still adds `net_posix.c` to `eos_net` for non-cross builds, the default host build documented in the README fails to compile when networking is disabled.

This includes the standard README build:

```bash
cmake -B build/host -DCMAKE_BUILD_TYPE=Release
cmake --build build/host --parallel
```

This PR wraps the implementation in `net_posix.c` with `#if EOS_ENABLE_NET` / `#endif`, following the existing pattern used by `net/src/net.c`, and adds CI coverage for configurations that leave eNet disabled.

## Type of Change

<!-- Check all that apply -->

- [ ] feat — New feature
- [x] fix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] refactor — Code restructuring without behavior change
- [ ] test — Add or fix tests
- [ ] build — Build system or dependency changes
- [x] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

<!-- List each change made in this PR -->

- Updated `net/src/net_posix.c` to compile its implementation only when `EOS_ENABLE_NET` is enabled, leaving an empty translation unit when networking is disabled.
- Added a `default-config` CI job in `.github/workflows/ci.yml` to build the default README configuration and selected product profiles where eNet is disabled.

## Testing

<!-- How was this tested? Which test suites were run? -->

- [x] Unit tests pass (`ctest --test-dir build/test --output-on-failure`)
- [ ] Integration tests pass
- [x] Manual testing performed
- [ ] New tests added for new functionality

Local test environment:

- WSL Ubuntu
- GCC 11.4.0

### Default host build

The README build was configured and built successfully:

```bash
cmake -B build/host -DCMAKE_BUILD_TYPE=Release
cmake --build build/host --parallel
```

The build completed successfully through 100%.

Before the fix, the same configuration failed in `net/src/net_posix.c` with errors such as:

```text
error: unknown type name 'eos_net_addr_t'
error: unknown type name 'eos_socket_t'
error: unknown type name 'eos_net_proto_t'
```

The root cause is that these types are unavailable when `EOS_ENABLE_NET=0`, while `net_posix.c` was still being compiled.

### Test suite

Configured and built the test profile with:

```bash
cmake -B build/test -DEOS_BUILD_TESTS=ON -DEOS_PRODUCT=vbox_test
cmake --build build/test --parallel
ctest --test-dir build/test --output-on-failure
```

Result:

```text
28/28 tests passed

100% tests passed, 0 tests failed out of 28

Total Test time (real) = 0.65 sec
```

### Regression coverage

The bug is configuration-dependent rather than a runtime behavior that can be meaningfully exercised by a ctest case.

The new CI job therefore builds:

- the default configuration shown in the README;
- the `medical` product profile;
- the `aerospace` product profile.

This ensures that configurations with `EOS_ENABLE_NET` disabled remain buildable.

## Pre-Submission Checklist

- [ ] Code compiles without warnings (`-Wall -Wextra -Werror` for C)
- [x] All existing tests pass
- [ ] New tests added for new functionality — CI build coverage added for the affected configurations
- [x] Documentation updated if API changed — no API change required
- [x] Commit messages follow `<type>(<scope>): <description>` convention
- [x] Branch is rebased on latest master

## Related Issues

Related to #102, which applies a similar empty-translation-unit guard to `hal_linux.c` under a different feature/platform condition.

This PR addresses the equivalent missing guard in `net_posix.c`; it is a separate issue and does not close #102.

## Screenshots / Logs

Before the fix, the default configuration fails while compiling `net/src/net_posix.c`:

```text
net/src/net_posix.c:43:30: error: unknown type name 'eos_net_addr_t'
net/src/net_posix.c:73:1: error: unknown type name 'eos_socket_t'
net/src/net_posix.c:73:29: error: unknown type name 'eos_net_proto_t'
```

After the fix, the default README build completes successfully:

```text
[100%] Linking C static library libeos_compat.a
[100%] Built target eos_compat
```

The test suite also completes successfully:

```text
28/28 Test #28: test_devicetree ............ Passed

100% tests passed, 0 tests failed out of 28
Total Test time (real) = 0.65 sec
```

## Additional Notes

The change does not alter networking behavior when `EOS_ENABLE_NET=1`. It only prevents the POSIX networking implementation from referencing unavailable eNet types when the feature is disabled.

The in-file guard follows the convention already used by `net/src/net.c`. I intentionally did not change the `target_sources()` condition in CMake because `EOS_ENABLE_NET` is handled as a compile definition elsewhere, and keeping the guard at the source level is consistent with the existing implementation pattern.

The local build produced several pre-existing compiler warnings in unrelated files, including warnings involving `strncpy`, `snprintf`, ignored return values, and similar code. The build nevertheless completed successfully, and this PR does not modify those warning-producing code paths.