### PR TITLE
fix(dm-verity): stop substituting a flat file digest for a Merkle root

### DIFF
--- a/services/linux/src/linux_security.c
+++ b/services/linux/src/linux_security.c
@@ -247,27 +247,32 @@ int eos_dmverity_create(EosDmVerity *dv, const char *image_path,
         pclose(proc);
     }
 
-    if (!dv->root_hash[0]) {
-        /* Fallback: compute SHA-256 of the image as a placeholder root hash */
-        char hex[65];
-        snprintf(cmd, sizeof(cmd), "sha256sum \"%s\" | cut -d' ' -f1", image_path);
-        proc = popen(cmd, "r");
-        if (proc) {
-            if (fgets(hex, sizeof(hex), proc)) {
-                char *nl = strchr(hex, '\n');
-                if (nl) *nl = '\0';
-                strncpy(dv->root_hash, hex, sizeof(dv->root_hash) - 1);
-            }
-            pclose(proc);
-        }
-    }
+    /* No sha256sum fallback.
+     *
+     * This used to run `sha256sum <image>` when veritysetup was unavailable or
+     * failed, and store the result in dv->root_hash. A dm-verity root hash is
+     * the root of a Merkle tree over the image's blocks -- it is what lets the
+     * kernel check each block as it is read. A flat digest of the whole file is
+     * a different thing that happens to be the same length, so the substitution
+     * was invisible: eos_dmverity_generate_table() would emit a table the
+     * kernel rejects, and anything treating root_hash as an integrity token got
+     * a value with none of dm-verity's properties.
+     *
+     * A hash device that could not be built is a failure. Reporting one is more
+     * useful than inventing a hash that cannot verify anything.
+     */
 #else
     (void)image_path;
     (void)hash_output;
 #endif
 
-    dv->verified = (dv->root_hash[0] != '\0');
-    return dv->verified ? 0 : -1;
+    /* `verified` says an image was checked against a known-good root hash.
+     * Formatting a hash device is not that check -- it establishes the root
+     * hash, it does not verify anything against it. Setting the flag here made
+     * every successful create() look like a completed verification to any
+     * caller that trusts the field, and eos_dmverity_verify() is the only
+     * function entitled to set it. */
+    return dv->root_hash[0] != '\0' ? 0 : -1;
 }
 
 int eos_dmverity_generate_table(const EosDmVerity *dv, char *table, size_t table_sz) {


### PR DESCRIPTION
`eos_dmverity_create()` has a fallback. If `veritysetup` is missing or fails, it runs `sha256sum <image>` and stores the result in `dv->root_hash`:

```c
if (!dv->root_hash[0]) {
    /* Fallback: compute SHA-256 of the image as a placeholder root hash */
    snprintf(cmd, sizeof(cmd), "sha256sum \"%s\" | cut -d' ' -f1", image_path);
    ...
}
```

**A dm-verity root hash is the root of a Merkle tree over the image's blocks.** That structure is the whole point — it is what lets the kernel check each block *as it is read*, lazily, at read time. A flat digest of the whole file is a different thing that happens to be the same length and the same shape, so the substitution is invisible in every printout and every string comparison.

What it is not is usable:

- `eos_dmverity_generate_table()` emits that value into a dm-verity table the kernel will reject
- anything treating `root_hash` as an integrity token holds a hash with **none of dm-verity's properties** — no per-block verification, no detection of tampering after mount

A hash device that could not be built is a failure. Reporting one is more useful than inventing a hash that cannot verify anything.

## Second, in the same function

```c
dv->verified = (dv->root_hash[0] != '\0');
return dv->verified ? 0 : -1;
```

`verified` means *an image was checked against a known-good root hash*. Creating a hash device is not that check — it **establishes** the root hash, it does not verify anything against it. Setting the flag here made every successful `create()` indistinguishable from a completed verification to any caller reading the field, `eos_dmverity_dump()` included.

`eos_dmverity_verify()` already sets it correctly, from `veritysetup verify`'s exit status, and is now the only place that does. `create()` returns the same `0`/`-1` as before, so its own callers are unaffected. `eos_dmverity_init()` memsets the struct, so `verified` starts false and stays false until something actually verifies.

## Verification

| | |
|---|---|
| `eos_linux_security` | builds clean |
| full Release suite | **25/28** |

The three `Not Run` are `services/compat/src/os_adapter_posix.c` needing `pthread_mutex_timedlock()` / `sem_timedwait()`, which macOS does not provide — **#96's subject, unrelated to this change**. Linux CI builds all 28.

## Deliberately not in this PR

This file drives `veritysetup`, `cryptsetup` and friends through `system()` / `popen()` with paths interpolated straight into shell strings — **ten call sites**. That is a real injection surface and its own piece of work; folding it into a correctness fix would bury both. Happy to take it as a follow-up.
