### PR TITLE
fix(crypto): let eos_crc32_file report a failed read

### DIFF
--- a/services/crypto/include/eos/crypto.h
+++ b/services/crypto/include/eos/crypto.h
@@ -59,6 +59,22 @@ void eos_sha512_hex(const uint8_t digest[EOS_SHA512_DIGEST_SIZE],
 
 uint32_t eos_crc32(uint32_t crc, const void *data, size_t len);
 uint32_t eos_crc32_file(const char *path);
+
+/**
+ * CRC-32 of a file, with the read result reported separately.
+ *
+ * eos_crc32_file() returns 0 both when the file cannot be read and when its
+ * CRC really is 0 -- which is the CRC of an empty file -- so a caller cannot
+ * tell the two apart. Every uint32_t is a valid CRC, so the status needs
+ * somewhere else to live.
+ *
+ * @param path File to read.
+ * @param out  Receives the CRC on success; left untouched on failure.
+ * @return 0 on success, -1 if path or out is NULL, the file cannot be
+ *         opened, or an error occurred while reading it.
+ */
+int eos_crc32_file_ex(const char *path, uint32_t *out);
+
 uint64_t eos_crc64(uint64_t crc, const void *data, size_t len);
 
 /* ---- AES-128 / AES-256 ---- */

--- a/services/crypto/src/crc.c
+++ b/services/crypto/src/crc.c
@@ -18,19 +18,46 @@ uint32_t eos_crc32(uint32_t crc, const void *data, size_t len) {
     return ~crc;
 }
 
-uint32_t eos_crc32_file(const char *path) {
+int eos_crc32_file_ex(const char *path, uint32_t *out) {
+    if (!path || !out) return -1;
+
     FILE *fp = fopen(path, "rb");
-    if (!fp) return 0;
+    if (!fp) return -1;
+
     uint32_t crc = 0;
     uint8_t buf[4096];
     size_t n;
-    while ((n = fread(buf, 1, sizeof(buf), fp)) > 0)
+
+    while ((n = fread(buf, 1, sizeof(buf), fp)) > 0) {
         crc = eos_crc32(crc, buf, n);
+    }
+
+    if (ferror(fp)) {
+        fclose(fp);
+        return -1;
+    }
+
     fclose(fp);
-    return crc;
+    *out = crc;
+    return 0;
 }
 
-/* ECMA-182 CRC-64 with polynomial 0x42F0E1EBA9EA3693 */
+/* Kept for callers that predate eos_crc32_file_ex(). The 0 it returns on a
+ * failed read is indistinguishable from the CRC of an empty file, so new code
+ * should use eos_crc32_file_ex(). */
+uint32_t eos_crc32_file(const char *path) {
+    uint32_t crc = 0;
+    return (eos_crc32_file_ex(path, &crc) == 0) ? crc : 0;
+}
+
+/* CRC-64/XZ: the ECMA-182 polynomial 0x42F0E1EBA9EA3693 in reflected form
+ * (0xC96C5795D7870F42), with an all-ones init and a final complement. Its
+ * check value for "123456789" is 0x995DC9BBDF1939FA.
+ *
+ * This is not CRC-64/ECMA-182 itself, which is MSB-first with a zero init and
+ * no final xor and checks to 0x6C40DF5F0B497347. Only the comment was wrong;
+ * the implementation is unchanged, since anything already holding a CRC-64
+ * computed it this way. */
 uint64_t eos_crc64(uint64_t crc, const void *data, size_t len) {
     const uint8_t *p = (const uint8_t *)data;
     crc = ~crc;

--- a/services/os/src/os_services.c
+++ b/services/os/src/os_services.c
@@ -338,7 +338,17 @@ int eos_integrity_check_crc32(const char *path, uint32_t expected_crc,
     memset(result, 0, sizeof(*result));
     strncpy(result->path, path, sizeof(result->path) - 1);
     result->expected_crc32 = expected_crc;
-    result->computed_crc32 = eos_crc32_file(path);
+
+    /* A file that cannot be read is not a file that matched. eos_crc32_file()
+     * returns 0 on a failed read, which is also the CRC of an empty file, so
+     * comparing its result directly let a missing file pass whenever the
+     * caller expected a CRC of 0. eos_integrity_check_sha256() above already
+     * treats an unreadable file as a failure. */
+    if (eos_crc32_file_ex(path, &result->computed_crc32) != 0) {
+        result->crc32_ok = 0;
+        return -1;
+    }
+
     result->crc32_ok = (result->computed_crc32 == expected_crc);
     return result->crc32_ok ? 0 : -1;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,11 @@ add_executable(test_crypto test_crypto.c)
 target_link_libraries(test_crypto PRIVATE eos_crypto)
 add_test(NAME test_crypto COMMAND test_crypto)
 
+# --- test_crc: CRC-32 / CRC-64 known answers and file error paths ---
+add_executable(test_crc test_crc.c)
+target_link_libraries(test_crc PRIVATE eos_crypto)
+add_test(NAME test_crc COMMAND test_crc)
+
 # --- test_crypto_aes / _ecc / _rsa / _sha512: were sitting in tests/ unused ---
 add_executable(test_crypto_aes test_crypto_aes.c)
 target_link_libraries(test_crypto_aes PRIVATE eos_crypto)

--- a/tests/test_crc.c
+++ b/tests/test_crc.c
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EoS Project
+// ISO/IEC 25000 | ISO/IEC/IEEE 15288:2023
+
+/**
+ * @file test_crc.c
+ * @brief Known-answer and error-path tests for the CRC-32 and CRC-64 helpers.
+ *
+ * test_crypto.c covers eos_crc32() over a buffer. Neither the file variant nor
+ * eos_crc64() had any coverage, and it was the file variant that could not
+ * report a failed read at all.
+ *
+ * Each case calls the function and inspects the out-parameter in separate
+ * statements: C does not sequence the arguments of a call against each other,
+ * so reading *out inside the same expression that fills it is undefined.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "eos/crypto.h"
+
+#define TMP_FILE "test_crc_tmp.bin"
+#define NO_FILE  "test_crc_no_such_file.bin"
+
+static void write_file(const char *path, const void *data, size_t len) {
+    FILE *fp = fopen(path, "wb");
+    assert(fp != NULL);
+    if (len > 0) {
+        assert(fwrite(data, 1, len, fp) == len);
+    }
+    assert(fclose(fp) == 0);
+}
+
+static void test_crc32_check_value(void) {
+    assert(eos_crc32(0, "123456789", 9) == 0xcbf43926u);
+    printf("[PASS] crc32 check value\n");
+}
+
+static void test_crc64_check_value(void) {
+    /* CRC-64/XZ. CRC-64/ECMA-182 would be 0x6c40df5f0b497347. */
+    assert(eos_crc64(0, "123456789", 9) == 0x995dc9bbdf1939faULL);
+    printf("[PASS] crc64 check value\n");
+}
+
+static void test_file_ex_missing(void) {
+    uint32_t crc = 0xdeadbeefu;
+    int r = eos_crc32_file_ex(NO_FILE, &crc);
+    assert(r == -1);
+    assert(crc == 0xdeadbeefu);   /* left untouched on failure */
+    printf("[PASS] crc32_file_ex reports a missing file\n");
+}
+
+static void test_file_ex_null_args(void) {
+    uint32_t crc = 0;
+    assert(eos_crc32_file_ex(NULL, &crc) == -1);
+    assert(eos_crc32_file_ex(TMP_FILE, NULL) == -1);
+    printf("[PASS] crc32_file_ex rejects NULL arguments\n");
+}
+
+static void test_file_ex_empty(void) {
+    /* The CRC of an empty file is 0 -- the same value eos_crc32_file()
+     * returns when it cannot open the file at all. This collision is why the
+     * status cannot live in the return value. */
+    write_file(TMP_FILE, "", 0);
+    uint32_t crc = 0xdeadbeefu;
+    int r = eos_crc32_file_ex(TMP_FILE, &crc);
+    assert(r == 0);
+    assert(crc == 0u);
+    assert(remove(TMP_FILE) == 0);
+    printf("[PASS] crc32_file_ex succeeds on an empty file\n");
+}
+
+static void test_file_ex_content(void) {
+    const char *msg = "123456789";
+    write_file(TMP_FILE, msg, 9);
+    uint32_t crc = 0;
+    int r = eos_crc32_file_ex(TMP_FILE, &crc);
+    assert(r == 0);
+    assert(crc == eos_crc32(0, msg, 9));
+    assert(crc == 0xcbf43926u);
+    assert(remove(TMP_FILE) == 0);
+    printf("[PASS] crc32_file_ex matches the buffer CRC\n");
+}
+
+static void test_file_ex_multi_block(void) {
+    /* Larger than the 4096-byte read buffer, so the chaining across reads is
+     * exercised rather than a single fread. */
+    size_t len = 10000;
+    uint8_t *big = malloc(len);
+    assert(big != NULL);
+    for (size_t i = 0; i < len; i++) big[i] = (uint8_t)(i * 7 + 3);
+
+    write_file(TMP_FILE, big, len);
+    uint32_t crc = 0;
+    int r = eos_crc32_file_ex(TMP_FILE, &crc);
+    assert(r == 0);
+    assert(crc == eos_crc32(0, big, len));
+    assert(remove(TMP_FILE) == 0);
+    free(big);
+    printf("[PASS] crc32_file_ex spans multiple read blocks\n");
+}
+
+static void test_file_legacy_unchanged(void) {
+    /* The old entry point keeps the behaviour its existing callers rely on. */
+    write_file(TMP_FILE, "123456789", 9);
+    assert(eos_crc32_file(TMP_FILE) == 0xcbf43926u);
+    assert(remove(TMP_FILE) == 0);
+    assert(eos_crc32_file(NO_FILE) == 0u);
+    printf("[PASS] crc32_file keeps its old behaviour\n");
+}
+
+int main(void) {
+    printf("=== CRC tests ===\n");
+    test_crc32_check_value();
+    test_crc64_check_value();
+    test_file_ex_missing();
+    test_file_ex_null_args();
+    test_file_ex_empty();
+    test_file_ex_content();
+    test_file_ex_multi_block();
+    test_file_legacy_unchanged();
+    printf("=== all CRC tests passed ===\n");
+    return 0;
+}


### PR DESCRIPTION
isn't the result. On failure *out is left untouched. It also fails on
ferror(), so a read that dies partway no longer reports the CRC of a prefix
as though it covered the whole file.

eos_crc32_file() keeps its existing signature and behaviour, reimplemented on
top of the new function. examples/ble-sensor/main.c:67 and any out-of-tree
caller are unaffected. Its declaration now carries a comment pointing new code
at the _ex variant.

eos_integrity_check_crc32() moves to the new function and returns -1 with
crc32_ok = 0 when the file cannot be read, matching its SHA-256 sibling.

I deliberately did not change eos_crc32_file()'s signature. The smaller
change is the one that does not break working callers to fix a bug only one
caller has.

Testing

New tests/test_crc.c, registered with ctest. eos_crc32() over a buffer was
covered by test_crypto.c; the file variant and eos_crc64() had no coverage,
and nothing exercised a file larger than the 4096-byte read buffer.