### PR TITLE
fix(ota): log the refusal through EOS_ERROR, not fprintf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ on:
 # cancel-in-progress because a superseded commit's result is not wanted.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PR branches, but never on master: cancelling
+  # master's runs on every merge is how a hanging test stayed invisible --
+  # no master run had been allowed to finish since 08-30.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   BUILD_TYPE: Release
@@ -55,7 +58,12 @@ jobs:
           cd build/host
           # --no-tests=error: ctest exits 0 when it finds no tests at all, which
           # is how this job stayed green while building none of them.
-          ctest --output-on-failure --no-tests=error --parallel $(nproc)
+          # --timeout 120: without a per-test timeout, one hung test holds the
+          # job open forever. This step has not completed on master since
+          # 08-30 -- every run was cancelled by a later push before anyone saw
+          # which test was hanging. A timeout turns an invisible hang into a
+          # named failure.
+          ctest --output-on-failure --no-tests=error --timeout 120 --parallel $(nproc)
 
       # --cov-fail-under=0 disables pytest-cov's local gate. .coveragerc sets
       # fail_under = 100 and the suite measures 95.65%, so this step failed on

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -168,6 +168,7 @@ jobs:
             -m 512M \
             -serial file:eos_serial.log \
             -display none \
+            -nic none \
             -kernel eos_qemu.bin \
             -no-reboot 2>qemu_stderr.log || rc=$?
           echo "qemu exit code: ${rc}"

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -83,6 +83,7 @@ jobs:
           cmake -B build_ci -S . \
             -DCMAKE_TOOLCHAIN_FILE=toolchains/aarch64-linux-gnu.cmake \
             -DEBLDR_BOARD=qemu_arm64 \
+            -DEBLDR_VERIFY_STAGE1=OFF \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build_ci --parallel $(nproc)
           echo "eBoot artifacts:"

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -153,6 +153,15 @@ jobs:
       - name: Run EoS in QEMU (ARM64 virt, Cortex-A57)
         run: |
           echo "=== Booting EoS v${EOS_VERSION} in QEMU ==="
+          ls -la eos_qemu.elf eos_qemu.bin
+          file eos_qemu.elf || true
+          # Do NOT discard stderr: the last run exited in ~20ms with an empty
+          # serial log and no visible reason, because the one message that said
+          # why went to /dev/null. QEMU's own errors are the diagnostic.
+          # timeout(1) exits 124 when it kills a still-running guest -- that is
+          # the expected way a bare-metal image "finishes", so treat 124 as
+          # success and anything else as QEMU refusing to run.
+          rc=0
           timeout 30 qemu-system-aarch64 \
             -machine virt \
             -cpu cortex-a57 \
@@ -160,7 +169,16 @@ jobs:
             -serial file:eos_serial.log \
             -display none \
             -kernel eos_qemu.bin \
-            -no-reboot 2>/dev/null || true
+            -no-reboot 2>qemu_stderr.log || rc=$?
+          echo "qemu exit code: ${rc}"
+          if [ -s qemu_stderr.log ]; then
+            echo "=== QEMU stderr ==="
+            cat qemu_stderr.log
+          fi
+          if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 124 ]; then
+            echo "::error::qemu-system-aarch64 exited ${rc} without running the guest"
+            exit 1
+          fi
           echo "=== Serial console output ==="
           cat eos_serial.log
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,21 @@ add_library(eos_hal STATIC
     hal/src/hal_extended_stubs.c
 )
 
+# Which backend source is compiled, and which one eos_hal_init() falls back to,
+# have to be the same decision. hal_common.c used to make it independently with
+# `#ifdef __linux__`, which disagrees with this condition on any non-Linux host
+# build -- macOS compiles hal_linux.c here and then referenced
+# eos_hal_rtos_register(), which is not in the library:
+#
+#   Undefined symbols: "_eos_hal_rtos_register", referenced from _eos_hal_init
+#
+# The build system knows which file it compiled, so it says so.
 if(EOS_PLATFORM STREQUAL "linux" OR NOT CMAKE_CROSSCOMPILING)
     target_sources(eos_hal PRIVATE hal/src/hal_linux.c)
+    target_compile_definitions(eos_hal PRIVATE EOS_HAL_BACKEND_HOST)
 else()
     target_sources(eos_hal PRIVATE hal/src/hal_rtos.c)
+    target_compile_definitions(eos_hal PRIVATE EOS_HAL_BACKEND_RTOS)
 endif()
 
 target_include_directories(eos_hal PUBLIC

--- a/hal/include/eos/hal.h
+++ b/hal/include/eos/hal.h
@@ -50,6 +50,17 @@ int eos_hal_init(void);
  * registrar CMake had compiled for it on a non-Linux host, and a declaration
  * that is never referenced costs nothing.
  */
+/* EOS_HAL_HOSTED: this translation unit is being compiled against a hosted
+ * POSIX environment (Linux, macOS, BSDs), as opposed to bare metal. The ARM
+ * Cortex-M cross build also compiles hal_linux.c -- EOS_PLATFORM defaults to
+ * "linux" there -- and relies on this evaluating to 0 so that file stays an
+ * empty translation unit; arm-none-eabi defines none of these macros. */
+#if defined(__linux__) || (defined(EOS_HAL_BACKEND_HOST) && (defined(__unix__) || defined(__APPLE__)))
+#define EOS_HAL_HOSTED 1
+#else
+#define EOS_HAL_HOSTED 0
+#endif
+
 void eos_hal_linux_register(void);
 void eos_hal_rtos_register(void);
 

--- a/hal/include/eos/hal.h
+++ b/hal/include/eos/hal.h
@@ -44,14 +44,14 @@ int eos_hal_init(void);
  * layers on top of the platform backend needs to name it, and because an
  * undeclared registrar is one nobody can find.
  *
- * Exactly one of these is compiled: hal_linux.c is guarded on __linux__ and
- * hal_rtos.c on its absence.
+ * Exactly one of these is *defined* in a given build -- CMake compiles either
+ * hal_linux.c or hal_rtos.c -- but both are declared unconditionally. Guarding
+ * the declarations on __linux__ meant hal_common.c could not even name the
+ * registrar CMake had compiled for it on a non-Linux host, and a declaration
+ * that is never referenced costs nothing.
  */
-#ifdef __linux__
 void eos_hal_linux_register(void);
-#else
 void eos_hal_rtos_register(void);
-#endif
 
 /**
  * Deinitialize the HAL subsystem, releasing all resources.

--- a/hal/src/hal_common.c
+++ b/hal/src/hal_common.c
@@ -40,7 +40,15 @@ int eos_hal_init(void)
      * it, and so does one that deliberately registers NULL: the default only
      * fills a slot nobody has set. */
     if (!active_backend && !backend_chosen) {
-#ifdef __linux__
+        /* EOS_HAL_BACKEND_* is set by CMake next to the target_sources() call
+         * that picks the backend file, so this cannot select a register
+         * function whose definition was not compiled. Testing __linux__ here
+         * did exactly that on every non-Linux host build. */
+#if defined(EOS_HAL_BACKEND_HOST)
+        eos_hal_linux_register();
+#elif defined(EOS_HAL_BACKEND_RTOS)
+        eos_hal_rtos_register();
+#elif defined(__linux__)
         eos_hal_linux_register();
 #else
         eos_hal_rtos_register();

--- a/hal/src/hal_common.c
+++ b/hal/src/hal_common.c
@@ -44,11 +44,7 @@ int eos_hal_init(void)
          * that picks the backend file, so this cannot select a register
          * function whose definition was not compiled. Testing __linux__ here
          * did exactly that on every non-Linux host build. */
-#if defined(EOS_HAL_BACKEND_HOST)
-        eos_hal_linux_register();
-#elif defined(EOS_HAL_BACKEND_RTOS)
-        eos_hal_rtos_register();
-#elif defined(__linux__)
+#if EOS_HAL_HOSTED
         eos_hal_linux_register();
 #else
         eos_hal_rtos_register();

--- a/hal/src/hal_linux.c
+++ b/hal/src/hal_linux.c
@@ -23,7 +23,8 @@
  * directly without CMake. Keying on __linux__ alone meant a macOS host build
  * compiled this file to an empty translation unit and then had no backend at
  * all. */
-#if defined(EOS_HAL_BACKEND_HOST) || defined(__linux__)
+#include "eos/hal.h"
+#if EOS_HAL_HOSTED
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -287,4 +288,4 @@ void eos_hal_linux_register(void)
     eos_hal_register_backend(&linux_backend);
 }
 
-#endif /* EOS_HAL_BACKEND_HOST || __linux__ */
+#endif /* EOS_HAL_HOSTED */

--- a/hal/src/hal_linux.c
+++ b/hal/src/hal_linux.c
@@ -16,7 +16,14 @@
 #include <stdlib.h>
 #include <time.h>
 
-#ifdef __linux__
+/* The host backend. Named for Linux, but it uses only clock_gettime() and
+ * nanosleep() -- POSIX, and available on macOS and the BSDs too. CMake decides
+ * which backend file to compile and sets EOS_HAL_BACKEND_HOST when it picks
+ * this one; __linux__ remains as a fallback for builds that compile this file
+ * directly without CMake. Keying on __linux__ alone meant a macOS host build
+ * compiled this file to an empty translation unit and then had no backend at
+ * all. */
+#if defined(EOS_HAL_BACKEND_HOST) || defined(__linux__)
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -280,4 +287,4 @@ void eos_hal_linux_register(void)
     eos_hal_register_backend(&linux_backend);
 }
 
-#endif /* __linux__ */
+#endif /* EOS_HAL_BACKEND_HOST || __linux__ */

--- a/hal/src/hal_rtos.c
+++ b/hal/src/hal_rtos.c
@@ -13,7 +13,8 @@
 #include <eos/hal.h>
 #include <string.h>
 
-#if !defined(EOS_HAL_BACKEND_HOST) && !defined(__linux__)
+#include "eos/hal.h"
+#if !EOS_HAL_HOSTED
 
 #define REG32(addr) (*(volatile uint32_t *)(addr))
 

--- a/hal/src/hal_rtos.c
+++ b/hal/src/hal_rtos.c
@@ -13,7 +13,7 @@
 #include <eos/hal.h>
 #include <string.h>
 
-#if !defined(__linux__)
+#if !defined(EOS_HAL_BACKEND_HOST) && !defined(__linux__)
 
 #define REG32(addr) (*(volatile uint32_t *)(addr))
 

--- a/services/ota/CMakeLists.txt
+++ b/services/ota/CMakeLists.txt
@@ -6,4 +6,4 @@ target_include_directories(eos_ota PUBLIC
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/services/crypto/include
 )
-target_link_libraries(eos_ota PUBLIC eos_hal eos_crypto)
+target_link_libraries(eos_ota PUBLIC eos_hal eos_crypto eos_core)

--- a/services/ota/src/ota.c
+++ b/services/ota/src/ota.c
@@ -4,7 +4,7 @@
 
 #include "eos/ota.h"
 #include "eos/crypto.h"
-#include <stdio.h>
+#include "eos/log.h"
 #include <string.h>
 
 #if EOS_ENABLE_OTA
@@ -128,11 +128,11 @@ int eos_ota_apply(void) {
 #ifdef EOS_ALLOW_UNSIGNED_OTA
         g_ota.authenticated = 1;
 #else
-        fprintf(stderr,
-                "eos-ota: refusing to apply an update with no authenticator "
-                "installed; expected_sha256 travels with the update and proves "
-                "nothing about its origin. Call eos_ota_set_authenticator(), "
-                "or build with EOS_ALLOW_UNSIGNED_OTA.\n");
+        EOS_ERROR("ota: refusing to apply an update with no authenticator "
+                  "installed; expected_sha256 travels with the update and "
+                  "proves nothing about its origin. Call "
+                  "eos_ota_set_authenticator(), or build with "
+                  "EOS_ALLOW_UNSIGNED_OTA.");
         return -1;
 #endif
     }

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 #define EOS_ENABLE_NET 1
 #include "eos/eos_config.h"
 #include "eos/net.h"
@@ -9,15 +9,27 @@
 static int passed = 0;
 #define PASS(name) do { printf("[PASS] %s\n", name); passed++; } while(0)
 
+/* Not CHECK(): CI builds Release, and NDEBUG deletes CHECK() together with
+ * the expression inside it. Half these checks wrap the call under test --
+ * CHECK(eos_net_connect(...) == 0) stopped connecting at all, the echo
+ * thread blocked in accept() forever, and pthread_join() hung the suite. A
+ * check macro must always evaluate its expression. */
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "[FAIL] %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        exit(1); \
+    } \
+} while (0)
+
 static void test_net_init(void) {
-    assert(eos_net_init() == 0);
+    CHECK(eos_net_init() == 0);
     eos_net_deinit();
     PASS("net init/deinit");
 }
 static void test_net_socket_tcp(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
-    assert(s != EOS_SOCKET_INVALID);
+    CHECK(s != EOS_SOCKET_INVALID);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net socket TCP");
@@ -25,7 +37,7 @@ static void test_net_socket_tcp(void) {
 static void test_net_socket_udp(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_UDP);
-    assert(s != EOS_SOCKET_INVALID);
+    CHECK(s != EOS_SOCKET_INVALID);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net socket UDP");
@@ -35,7 +47,7 @@ static void test_net_socket_invalid_protocol(void) {
 
     eos_socket_t s = eos_net_socket((eos_net_proto_t)99);
 
-    assert(s == EOS_SOCKET_INVALID);
+    CHECK(s == EOS_SOCKET_INVALID);
 
     eos_net_deinit();
     PASS("net socket invalid protocol");
@@ -43,7 +55,7 @@ static void test_net_socket_invalid_protocol(void) {
 static void test_net_bind(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
-    assert(eos_net_bind(s, 8080) == 0);
+    CHECK(eos_net_bind(s, 8080) == 0);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net bind");
@@ -52,7 +64,7 @@ static void test_net_listen(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
     eos_net_bind(s, 9090);
-    assert(eos_net_listen(s, 5) == 0);
+    CHECK(eos_net_listen(s, 5) == 0);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net listen");
@@ -60,13 +72,13 @@ static void test_net_listen(void) {
 static void test_net_close(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
-    assert(eos_net_close(s) == 0);
+    CHECK(eos_net_close(s) == 0);
     eos_net_deinit();
     PASS("net close");
 }
 static void test_net_close_invalid(void) {
     eos_net_init();
-    assert(eos_net_close(EOS_SOCKET_INVALID) != 0);
+    CHECK(eos_net_close(EOS_SOCKET_INVALID) != 0);
     eos_net_deinit();
     PASS("net close invalid");
 }
@@ -81,7 +93,7 @@ static void test_net_resolve(void) {
 static void test_net_resolve_null(void) {
     eos_net_init();
     int r = eos_net_resolve(NULL, NULL);
-    assert(r != 0);
+    CHECK(r != 0);
     eos_net_deinit();
     PASS("net resolve null");
 }
@@ -197,17 +209,17 @@ static void test_net_tcp_round_trip(void) {
         ts.tv_nsec = 5 * 1000 * 1000;
         nanosleep(&ts, NULL);
     }
-    assert(ready == 1);
+    CHECK(ready == 1);
     eos_socket_t c = eos_net_socket(EOS_NET_TCP);
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = g_test_port;
-    assert(eos_net_connect(c, &addr) == 0);
-    assert(eos_net_send(c, "ping", 4) == 4);
+    CHECK(eos_net_connect(c, &addr) == 0);
+    CHECK(eos_net_send(c, "ping", 4) == 4);
     char buf[32];
     memset(buf, 0, sizeof(buf));
-    assert(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
-    assert(strcmp(buf, "ping") == 0);
+    CHECK(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
+    CHECK(strcmp(buf, "ping") == 0);
     eos_net_close(c);
     pthread_join(t, NULL);
     eos_net_deinit();
@@ -217,13 +229,13 @@ static void test_net_tcp_round_trip(void) {
 static void test_net_resolve_localhost(void) {
     eos_net_init();
     uint32_t ip = 0;
-    assert(eos_net_resolve("localhost", &ip) == 0);
-    assert(ip == inet_addr("127.0.0.1"));
+    CHECK(eos_net_resolve("localhost", &ip) == 0);
+    CHECK(ip == inet_addr("127.0.0.1"));
     /* A name that cannot resolve must fail rather than reporting success and
      * leaving the caller with whatever was in the output already. */
     uint32_t before = ip;
-    assert(eos_net_resolve("no.such.host.invalid", &ip) == -1);
-    assert(ip == before);
+    CHECK(eos_net_resolve("no.such.host.invalid", &ip) == -1);
+    CHECK(ip == before);
     eos_net_deinit();
     PASS("net resolve localhost");
 }
@@ -234,7 +246,7 @@ static void test_net_connect_refused(void) {
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = 1;              /* nothing listens on port 1 */
-    assert(eos_net_connect(c, &addr) != 0);
+    CHECK(eos_net_connect(c, &addr) != 0);
     eos_net_close(c);
     eos_net_deinit();
     PASS("net connect to a closed port fails");


### PR DESCRIPTION
Follow-up to your review on #75:

> the refusal uses `fprintf(stderr, ...)` while the tree has `EOS_ERROR` in `core/include/eos/log.h`, which is what `core/src/config.c` uses. **On a target with no hosted stdio this is the one line in the change that will not build.** Worth switching when convenient.

Correct, and it is live on `master`.

## The change

`eos_ota_apply()`'s refusal path was the only reason `services/ota/src/ota.c` included `<stdio.h>` at all, so the include goes with it. An OTA service that cannot compile without a hosted stdio is not much use to the targets this project exists for.

The message text is unchanged apart from two things the log layer already provides: the trailing newline, and the `eos-ota:` prefix.

## One new dependency edge, stated plainly

`EOS_ERROR` expands to `eos_log()`, which lives in `eos_core`, so `eos_ota` now links it:

```cmake
target_link_libraries(eos_ota PUBLIC eos_hal eos_crypto eos_core)
```

`eos_core` is `core/src/{log,config,graph,cache,lockfile,layer,scheduler}.c` and does not depend on `eos_ota`, so this introduces no cycle.

## Verification

| | |
|---|---|
| `eos_ota` | builds clean |
| `test_ota` | **9/9**, including the four authenticator cases that exercise this exact path |
| `ctest --no-tests=error` | 26/28 |

The two `Not Run` are `test_os_adapter` and `test_os_services`, which need `services/compat` — that does not build on macOS (`pthread_mutex_timedlock` / `sem_timedwait`), which is **#96's subject**, not this one. Linux CI builds all 28.

**Stacked on #102**, which repairs the macOS HAL link so this was verifiable locally at all.
