### PR TITLE
fix(mpu): reject regions the MPU cannot program, and stop dividing by zero

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ on:
 # cancel-in-progress because a superseded commit's result is not wanted.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PR branches, but never on master: cancelling
+  # master's runs on every merge is how a hanging test stayed invisible --
+  # no master run had been allowed to finish since 08-30.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   BUILD_TYPE: Release
@@ -55,7 +58,12 @@ jobs:
           cd build/host
           # --no-tests=error: ctest exits 0 when it finds no tests at all, which
           # is how this job stayed green while building none of them.
-          ctest --output-on-failure --no-tests=error --parallel $(nproc)
+          # --timeout 120: without a per-test timeout, one hung test holds the
+          # job open forever. This step has not completed on master since
+          # 08-30 -- every run was cancelled by a later push before anyone saw
+          # which test was hanging. A timeout turns an invisible hang into a
+          # named failure.
+          ctest --output-on-failure --no-tests=error --timeout 120 --parallel $(nproc)
 
       # --cov-fail-under=0 disables pytest-cov's local gate. .coveragerc sets
       # fail_under = 100 and the suite measures 95.65%, so this step failed on

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -168,6 +168,7 @@ jobs:
             -m 512M \
             -serial file:eos_serial.log \
             -display none \
+            -nic none \
             -kernel eos_qemu.bin \
             -no-reboot 2>qemu_stderr.log || rc=$?
           echo "qemu exit code: ${rc}"

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -83,6 +83,7 @@ jobs:
           cmake -B build_ci -S . \
             -DCMAKE_TOOLCHAIN_FILE=toolchains/aarch64-linux-gnu.cmake \
             -DEBLDR_BOARD=qemu_arm64 \
+            -DEBLDR_VERIFY_STAGE1=OFF \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build_ci --parallel $(nproc)
           echo "eBoot artifacts:"

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -153,6 +153,15 @@ jobs:
       - name: Run EoS in QEMU (ARM64 virt, Cortex-A57)
         run: |
           echo "=== Booting EoS v${EOS_VERSION} in QEMU ==="
+          ls -la eos_qemu.elf eos_qemu.bin
+          file eos_qemu.elf || true
+          # Do NOT discard stderr: the last run exited in ~20ms with an empty
+          # serial log and no visible reason, because the one message that said
+          # why went to /dev/null. QEMU's own errors are the diagnostic.
+          # timeout(1) exits 124 when it kills a still-running guest -- that is
+          # the expected way a bare-metal image "finishes", so treat 124 as
+          # success and anything else as QEMU refusing to run.
+          rc=0
           timeout 30 qemu-system-aarch64 \
             -machine virt \
             -cpu cortex-a57 \
@@ -160,7 +169,16 @@ jobs:
             -serial file:eos_serial.log \
             -display none \
             -kernel eos_qemu.bin \
-            -no-reboot 2>/dev/null || true
+            -no-reboot 2>qemu_stderr.log || rc=$?
+          echo "qemu exit code: ${rc}"
+          if [ -s qemu_stderr.log ]; then
+            echo "=== QEMU stderr ==="
+            cat qemu_stderr.log
+          fi
+          if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 124 ]; then
+            echo "::error::qemu-system-aarch64 exited ${rc} without running the guest"
+            exit 1
+          fi
           echo "=== Serial console output ==="
           cat eos_serial.log
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,21 @@ add_library(eos_hal STATIC
     hal/src/hal_extended_stubs.c
 )
 
+# Which backend source is compiled, and which one eos_hal_init() falls back to,
+# have to be the same decision. hal_common.c used to make it independently with
+# `#ifdef __linux__`, which disagrees with this condition on any non-Linux host
+# build -- macOS compiles hal_linux.c here and then referenced
+# eos_hal_rtos_register(), which is not in the library:
+#
+#   Undefined symbols: "_eos_hal_rtos_register", referenced from _eos_hal_init
+#
+# The build system knows which file it compiled, so it says so.
 if(EOS_PLATFORM STREQUAL "linux" OR NOT CMAKE_CROSSCOMPILING)
     target_sources(eos_hal PRIVATE hal/src/hal_linux.c)
+    target_compile_definitions(eos_hal PRIVATE EOS_HAL_BACKEND_HOST)
 else()
     target_sources(eos_hal PRIVATE hal/src/hal_rtos.c)
+    target_compile_definitions(eos_hal PRIVATE EOS_HAL_BACKEND_RTOS)
 endif()
 
 target_include_directories(eos_hal PUBLIC

--- a/hal/include/eos/hal.h
+++ b/hal/include/eos/hal.h
@@ -50,6 +50,17 @@ int eos_hal_init(void);
  * registrar CMake had compiled for it on a non-Linux host, and a declaration
  * that is never referenced costs nothing.
  */
+/* EOS_HAL_HOSTED: this translation unit is being compiled against a hosted
+ * POSIX environment (Linux, macOS, BSDs), as opposed to bare metal. The ARM
+ * Cortex-M cross build also compiles hal_linux.c -- EOS_PLATFORM defaults to
+ * "linux" there -- and relies on this evaluating to 0 so that file stays an
+ * empty translation unit; arm-none-eabi defines none of these macros. */
+#if defined(__linux__) || (defined(EOS_HAL_BACKEND_HOST) && (defined(__unix__) || defined(__APPLE__)))
+#define EOS_HAL_HOSTED 1
+#else
+#define EOS_HAL_HOSTED 0
+#endif
+
 void eos_hal_linux_register(void);
 void eos_hal_rtos_register(void);
 

--- a/hal/include/eos/hal.h
+++ b/hal/include/eos/hal.h
@@ -44,14 +44,14 @@ int eos_hal_init(void);
  * layers on top of the platform backend needs to name it, and because an
  * undeclared registrar is one nobody can find.
  *
- * Exactly one of these is compiled: hal_linux.c is guarded on __linux__ and
- * hal_rtos.c on its absence.
+ * Exactly one of these is *defined* in a given build -- CMake compiles either
+ * hal_linux.c or hal_rtos.c -- but both are declared unconditionally. Guarding
+ * the declarations on __linux__ meant hal_common.c could not even name the
+ * registrar CMake had compiled for it on a non-Linux host, and a declaration
+ * that is never referenced costs nothing.
  */
-#ifdef __linux__
 void eos_hal_linux_register(void);
-#else
 void eos_hal_rtos_register(void);
-#endif
 
 /**
  * Deinitialize the HAL subsystem, releasing all resources.

--- a/hal/src/hal_common.c
+++ b/hal/src/hal_common.c
@@ -40,7 +40,15 @@ int eos_hal_init(void)
      * it, and so does one that deliberately registers NULL: the default only
      * fills a slot nobody has set. */
     if (!active_backend && !backend_chosen) {
-#ifdef __linux__
+        /* EOS_HAL_BACKEND_* is set by CMake next to the target_sources() call
+         * that picks the backend file, so this cannot select a register
+         * function whose definition was not compiled. Testing __linux__ here
+         * did exactly that on every non-Linux host build. */
+#if defined(EOS_HAL_BACKEND_HOST)
+        eos_hal_linux_register();
+#elif defined(EOS_HAL_BACKEND_RTOS)
+        eos_hal_rtos_register();
+#elif defined(__linux__)
         eos_hal_linux_register();
 #else
         eos_hal_rtos_register();

--- a/hal/src/hal_common.c
+++ b/hal/src/hal_common.c
@@ -44,11 +44,7 @@ int eos_hal_init(void)
          * that picks the backend file, so this cannot select a register
          * function whose definition was not compiled. Testing __linux__ here
          * did exactly that on every non-Linux host build. */
-#if defined(EOS_HAL_BACKEND_HOST)
-        eos_hal_linux_register();
-#elif defined(EOS_HAL_BACKEND_RTOS)
-        eos_hal_rtos_register();
-#elif defined(__linux__)
+#if EOS_HAL_HOSTED
         eos_hal_linux_register();
 #else
         eos_hal_rtos_register();

--- a/hal/src/hal_linux.c
+++ b/hal/src/hal_linux.c
@@ -23,7 +23,8 @@
  * directly without CMake. Keying on __linux__ alone meant a macOS host build
  * compiled this file to an empty translation unit and then had no backend at
  * all. */
-#if defined(EOS_HAL_BACKEND_HOST) || defined(__linux__)
+#include "eos/hal.h"
+#if EOS_HAL_HOSTED
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -287,4 +288,4 @@ void eos_hal_linux_register(void)
     eos_hal_register_backend(&linux_backend);
 }
 
-#endif /* EOS_HAL_BACKEND_HOST || __linux__ */
+#endif /* EOS_HAL_HOSTED */

--- a/hal/src/hal_linux.c
+++ b/hal/src/hal_linux.c
@@ -16,7 +16,14 @@
 #include <stdlib.h>
 #include <time.h>
 
-#ifdef __linux__
+/* The host backend. Named for Linux, but it uses only clock_gettime() and
+ * nanosleep() -- POSIX, and available on macOS and the BSDs too. CMake decides
+ * which backend file to compile and sets EOS_HAL_BACKEND_HOST when it picks
+ * this one; __linux__ remains as a fallback for builds that compile this file
+ * directly without CMake. Keying on __linux__ alone meant a macOS host build
+ * compiled this file to an empty translation unit and then had no backend at
+ * all. */
+#if defined(EOS_HAL_BACKEND_HOST) || defined(__linux__)
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -280,4 +287,4 @@ void eos_hal_linux_register(void)
     eos_hal_register_backend(&linux_backend);
 }
 
-#endif /* __linux__ */
+#endif /* EOS_HAL_BACKEND_HOST || __linux__ */

--- a/hal/src/hal_rtos.c
+++ b/hal/src/hal_rtos.c
@@ -13,7 +13,8 @@
 #include <eos/hal.h>
 #include <string.h>
 
-#if !defined(EOS_HAL_BACKEND_HOST) && !defined(__linux__)
+#include "eos/hal.h"
+#if !EOS_HAL_HOSTED
 
 #define REG32(addr) (*(volatile uint32_t *)(addr))
 

--- a/hal/src/hal_rtos.c
+++ b/hal/src/hal_rtos.c
@@ -13,7 +13,7 @@
 #include <eos/hal.h>
 #include <string.h>
 
-#if !defined(__linux__)
+#if !defined(EOS_HAL_BACKEND_HOST) && !defined(__linux__)
 
 #define REG32(addr) (*(volatile uint32_t *)(addr))
 

--- a/services/rtos/include/eos/rtos_security.h
+++ b/services/rtos/include/eos/rtos_security.h
@@ -20,6 +20,9 @@
 /* ---- MPU-based Task Isolation ---- */
 
 #define EOS_MPU_MAX_REGIONS   16
+/* ARMv7-M RASR.SIZE encodes 2^(SIZE+1) bytes with SIZE >= 4, so the
+ * smallest region the hardware can express is 32 bytes. */
+#define EOS_MPU_MIN_REGION_SIZE 32u
 #define EOS_MPU_MAX_TASKS     32
 
 typedef enum {

--- a/services/rtos/src/rtos_security.c
+++ b/services/rtos/src/rtos_security.c
@@ -72,14 +72,47 @@ int eos_mpu_validate(const EosMpuConfig *mpu) {
         }
         for (int r = 0; r < task->region_count; r++) {
             const EosMpuRegion *reg = &task->regions[r];
-            /* Check power-of-2 alignment (ARM MPU requirement) */
-            if (reg->size > 0 && (reg->size & (reg->size - 1)) != 0) {
-                printf("  WARN: Task '%s' region '%s' size 0x%x not power-of-2\n",
-                       task->task_name, reg->label, reg->size);
+
+            /* These are errors, not warnings.
+             *
+             * ARMv7-M encodes a region's extent as a power-of-two exponent in
+             * RASR.SIZE, and RBAR requires the base to be aligned to that
+             * extent. A region that violates either cannot be expressed: what
+             * gets programmed covers different memory than was asked for. For
+             * a task-isolation service, "isolated, but not over the range you
+             * specified" is the failure this validation exists to catch, so it
+             * has to count against the return value rather than print a note
+             * and report the configuration clean. */
+            if (reg->size == 0) {
+                printf("  ERROR: Task '%s' region '%s' has size 0\n",
+                       task->task_name, reg->label);
+                errors++;
+                continue;   /* every check below divides by or masks with size */
             }
-            if (reg->base_addr % reg->size != 0 && reg->size > 0) {
-                printf("  WARN: Task '%s' region '%s' base 0x%x not aligned to size 0x%x\n",
+            if ((reg->size & (reg->size - 1)) != 0) {
+                printf("  ERROR: Task '%s' region '%s' size 0x%x not power-of-2\n",
+                       task->task_name, reg->label, reg->size);
+                errors++;
+            }
+            if (reg->size < EOS_MPU_MIN_REGION_SIZE) {
+                printf("  ERROR: Task '%s' region '%s' size 0x%x below the "
+                       "%u-byte minimum\n",
+                       task->task_name, reg->label, reg->size,
+                       (unsigned)EOS_MPU_MIN_REGION_SIZE);
+                errors++;
+            }
+            /* Guarded by the size == 0 check above: `base % size` with size 0
+             * is undefined. It was previously written as
+             * `reg->base_addr % reg->size != 0 && reg->size > 0`, and && only
+             * guards what is to its right -- so the modulo ran first and a
+             * zero-sized region divided by zero. UBSan aborts on it; on x86
+             * that is SIGFPE, while AArch64's udiv quietly yields 0, so it
+             * reproduced only on some hosts. */
+            if (reg->base_addr % reg->size != 0) {
+                printf("  ERROR: Task '%s' region '%s' base 0x%x not aligned "
+                       "to size 0x%x\n",
                        task->task_name, reg->label, reg->base_addr, reg->size);
+                errors++;
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,11 @@ add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)
 add_test(NAME test_crypto_sha512 COMMAND test_crypto_sha512)
 
+# --- test_mpu_validate: MPU region programmability ---
+add_executable(test_mpu_validate test_mpu_validate.c)
+target_link_libraries(test_mpu_validate PRIVATE eos_rtos_security)
+add_test(NAME test_mpu_validate COMMAND test_mpu_validate)
+
 # --- test_security: Keystore, ACL ---
 add_executable(test_security test_security.c)
 target_link_libraries(test_security PRIVATE eos_security eos_crypto)

--- a/tests/test_mpu_validate.c
+++ b/tests/test_mpu_validate.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EoS Project
+
+/**
+ * @file test_mpu_validate.c
+ * @brief eos_mpu_validate() must reject regions the MPU cannot program
+ *
+ * ARMv7-M encodes a region's extent as a power-of-two exponent in RASR.SIZE
+ * and requires RBAR's base to be aligned to that extent. A region violating
+ * either cannot be expressed, so what gets programmed covers different memory
+ * than was requested -- which for a task-isolation service is the failure the
+ * validation exists to catch.
+ *
+ * Those two checks used to print WARN and leave the error count at zero, so
+ * eos_mpu_validate() reported an unprogrammable configuration as clean.
+ */
+
+#include "eos/rtos_security.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int passed = 0;
+#define PASS(name) do { printf("[PASS] %s\n", name); passed++; } while (0)
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "[FAIL] %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        exit(1); \
+    } \
+} while (0)
+
+/* One task with a single region, described by the caller. */
+static int validate_one_region(uint32_t base, uint32_t size)
+{
+    EosMpuConfig m;
+    eos_mpu_init(&m, 8);
+    CHECK(eos_mpu_add_task(&m, "worker", 1, 0) == 0);
+    CHECK(eos_mpu_add_region(&m, 0, "r", base, size,
+                             EOS_MPU_RW, EOS_MPU_MEM_SRAM) == 0);
+    return eos_mpu_validate(&m);
+}
+
+static void test_a_programmable_region_validates_clean(void)
+{
+    /* 4 KiB at a 4 KiB-aligned base: expressible, so no errors. */
+    CHECK(validate_one_region(0x20001000, 0x1000) == 0);
+    PASS("mpu: a programmable region validates clean");
+}
+
+static void test_non_power_of_two_size_is_an_error(void)
+{
+    /* 0x1800 is not 2^n; RASR.SIZE cannot encode it. */
+    CHECK(validate_one_region(0x20000000, 0x1800) > 0);
+    PASS("mpu: non-power-of-two size is an error");
+}
+
+static void test_misaligned_base_is_an_error(void)
+{
+    /* 4 KiB region based 0x100 into a page: RBAR cannot encode it. */
+    CHECK(validate_one_region(0x20000100, 0x1000) > 0);
+    PASS("mpu: base not aligned to size is an error");
+}
+
+/* `reg->base_addr % reg->size != 0 && reg->size > 0` divides before it checks:
+ * && only guards what is to its right. UBSan aborts here; on x86 a zero
+ * divisor is SIGFPE, while AArch64's udiv quietly yields 0 -- so this
+ * reproduced on some hosts and not others. */
+static void test_zero_size_is_an_error_and_does_not_divide_by_zero(void)
+{
+    CHECK(validate_one_region(0x20000000, 0) > 0);
+    PASS("mpu: zero size is an error, with no division by zero");
+}
+
+static void test_size_below_the_hardware_minimum_is_an_error(void)
+{
+    /* 16 bytes is a power of two and aligned, but below the 32-byte floor. */
+    CHECK(validate_one_region(0x20000000, 16) > 0);
+    PASS("mpu: size below the 32-byte minimum is an error");
+}
+
+/* Errors accumulate rather than masking one another. */
+static void test_a_task_over_its_hardware_region_budget_still_counts(void)
+{
+    EosMpuConfig m;
+    eos_mpu_init(&m, 2);            /* only 2 hardware regions */
+    CHECK(eos_mpu_add_task(&m, "worker", 1, 0) == 0);
+    CHECK(eos_mpu_add_region(&m, 0, "ok", 0x20000000, 0x1000,
+                             EOS_MPU_RW, EOS_MPU_MEM_SRAM) == 0);
+    CHECK(eos_mpu_add_region(&m, 0, "bad", 0x20004000, 0x1800,
+                             EOS_MPU_RW, EOS_MPU_MEM_SRAM) == 0);
+    /* The unprogrammable size must be counted even though the region budget
+     * is satisfied. */
+    CHECK(eos_mpu_validate(&m) > 0);
+    PASS("mpu: an unprogrammable region counts within the region budget");
+}
+
+int main(void)
+{
+    printf("=== EoS MPU Validation Tests ===\n");
+    test_a_programmable_region_validates_clean();
+    test_non_power_of_two_size_is_an_error();
+    test_misaligned_base_is_an_error();
+    test_zero_size_is_an_error_and_does_not_divide_by_zero();
+    test_size_below_the_hardware_minimum_is_an_error();
+    test_a_task_over_its_hardware_region_budget_still_counts();
+    printf("=== ALL %d MPU TESTS PASSED ===\n", passed);
+    return 0;
+}

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 #define EOS_ENABLE_NET 1
 #include "eos/eos_config.h"
 #include "eos/net.h"
@@ -9,15 +9,27 @@
 static int passed = 0;
 #define PASS(name) do { printf("[PASS] %s\n", name); passed++; } while(0)
 
+/* Not CHECK(): CI builds Release, and NDEBUG deletes CHECK() together with
+ * the expression inside it. Half these checks wrap the call under test --
+ * CHECK(eos_net_connect(...) == 0) stopped connecting at all, the echo
+ * thread blocked in accept() forever, and pthread_join() hung the suite. A
+ * check macro must always evaluate its expression. */
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "[FAIL] %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        exit(1); \
+    } \
+} while (0)
+
 static void test_net_init(void) {
-    assert(eos_net_init() == 0);
+    CHECK(eos_net_init() == 0);
     eos_net_deinit();
     PASS("net init/deinit");
 }
 static void test_net_socket_tcp(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
-    assert(s != EOS_SOCKET_INVALID);
+    CHECK(s != EOS_SOCKET_INVALID);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net socket TCP");
@@ -25,7 +37,7 @@ static void test_net_socket_tcp(void) {
 static void test_net_socket_udp(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_UDP);
-    assert(s != EOS_SOCKET_INVALID);
+    CHECK(s != EOS_SOCKET_INVALID);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net socket UDP");
@@ -35,7 +47,7 @@ static void test_net_socket_invalid_protocol(void) {
 
     eos_socket_t s = eos_net_socket((eos_net_proto_t)99);
 
-    assert(s == EOS_SOCKET_INVALID);
+    CHECK(s == EOS_SOCKET_INVALID);
 
     eos_net_deinit();
     PASS("net socket invalid protocol");
@@ -43,7 +55,7 @@ static void test_net_socket_invalid_protocol(void) {
 static void test_net_bind(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
-    assert(eos_net_bind(s, 8080) == 0);
+    CHECK(eos_net_bind(s, 8080) == 0);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net bind");
@@ -52,7 +64,7 @@ static void test_net_listen(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
     eos_net_bind(s, 9090);
-    assert(eos_net_listen(s, 5) == 0);
+    CHECK(eos_net_listen(s, 5) == 0);
     eos_net_close(s);
     eos_net_deinit();
     PASS("net listen");
@@ -60,13 +72,13 @@ static void test_net_listen(void) {
 static void test_net_close(void) {
     eos_net_init();
     eos_socket_t s = eos_net_socket(EOS_NET_TCP);
-    assert(eos_net_close(s) == 0);
+    CHECK(eos_net_close(s) == 0);
     eos_net_deinit();
     PASS("net close");
 }
 static void test_net_close_invalid(void) {
     eos_net_init();
-    assert(eos_net_close(EOS_SOCKET_INVALID) != 0);
+    CHECK(eos_net_close(EOS_SOCKET_INVALID) != 0);
     eos_net_deinit();
     PASS("net close invalid");
 }
@@ -81,7 +93,7 @@ static void test_net_resolve(void) {
 static void test_net_resolve_null(void) {
     eos_net_init();
     int r = eos_net_resolve(NULL, NULL);
-    assert(r != 0);
+    CHECK(r != 0);
     eos_net_deinit();
     PASS("net resolve null");
 }
@@ -197,17 +209,17 @@ static void test_net_tcp_round_trip(void) {
         ts.tv_nsec = 5 * 1000 * 1000;
         nanosleep(&ts, NULL);
     }
-    assert(ready == 1);
+    CHECK(ready == 1);
     eos_socket_t c = eos_net_socket(EOS_NET_TCP);
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = g_test_port;
-    assert(eos_net_connect(c, &addr) == 0);
-    assert(eos_net_send(c, "ping", 4) == 4);
+    CHECK(eos_net_connect(c, &addr) == 0);
+    CHECK(eos_net_send(c, "ping", 4) == 4);
     char buf[32];
     memset(buf, 0, sizeof(buf));
-    assert(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
-    assert(strcmp(buf, "ping") == 0);
+    CHECK(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
+    CHECK(strcmp(buf, "ping") == 0);
     eos_net_close(c);
     pthread_join(t, NULL);
     eos_net_deinit();
@@ -217,13 +229,13 @@ static void test_net_tcp_round_trip(void) {
 static void test_net_resolve_localhost(void) {
     eos_net_init();
     uint32_t ip = 0;
-    assert(eos_net_resolve("localhost", &ip) == 0);
-    assert(ip == inet_addr("127.0.0.1"));
+    CHECK(eos_net_resolve("localhost", &ip) == 0);
+    CHECK(ip == inet_addr("127.0.0.1"));
     /* A name that cannot resolve must fail rather than reporting success and
      * leaving the caller with whatever was in the output already. */
     uint32_t before = ip;
-    assert(eos_net_resolve("no.such.host.invalid", &ip) == -1);
-    assert(ip == before);
+    CHECK(eos_net_resolve("no.such.host.invalid", &ip) == -1);
+    CHECK(ip == before);
     eos_net_deinit();
     PASS("net resolve localhost");
 }
@@ -234,7 +246,7 @@ static void test_net_connect_refused(void) {
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = 1;              /* nothing listens on port 1 */
-    assert(eos_net_connect(c, &addr) != 0);
+    CHECK(eos_net_connect(c, &addr) != 0);
     eos_net_close(c);
     eos_net_deinit();
     PASS("net connect to a closed port fails");


### PR DESCRIPTION
`eos_mpu_validate()` returns an error count, and its two hardware-constraint checks did not contribute to it:

```c
if (reg->size > 0 && (reg->size & (reg->size - 1)) != 0)
    printf("  WARN: ... size 0x%x not power-of-2\n", ...);
if (reg->base_addr % reg->size != 0 && reg->size > 0)
    printf("  WARN: ... base 0x%x not aligned to size 0x%x\n", ...);
```

Neither touches `errors`, so a configuration the hardware **cannot program** is reported clean — and `eos_mpu_generate_config()` writes it out.

## These are not warnings

ARMv7-M encodes a region's extent as a power-of-two exponent in `RASR.SIZE`, and `RBAR` requires the base to be aligned to that extent. A region violating either **cannot be expressed** — what actually gets programmed covers different memory than was asked for.

For a task-isolation service, *"isolated, but not over the range you specified"* is precisely the failure this validation exists to catch. Both now count against the return value, along with the 32-byte floor `RASR.SIZE` implies, which nothing checked at all.

## Second: the guard is on the wrong side of `&&`

```c
reg->base_addr % reg->size != 0 && reg->size > 0
```

`&&` only guards what is to its *right*, so the modulo runs first and a zero-sized region divides by zero. `eos_mpu_add_region()` never validates `size`, so this is reachable from any caller:

```
services/rtos/src/rtos_security.c:80:32: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
```

**Worth knowing why it went unnoticed:** on x86 a zero divisor raises `SIGFPE` and the process dies; AArch64's `udiv` quietly yields 0. The same input crashes on the CI host and returns silently on an Apple-silicon dev machine — I hit exactly that, and only UBSan settled it.

Size 0 is now rejected first, and the check `continue`s past everything that divides by or masks with size.

## Tests

`tests/test_mpu_validate.c` is new — **this service had no tests**. It covers a programmable region validating clean, then each rejection: non-power-of-two, misaligned base, zero size, below the 32-byte minimum, and an unprogrammable region inside a *satisfied* region budget (so one error cannot mask another).

Against the unpatched `validate()` it fails on the non-power-of-two case:

```
[FAIL] test_mpu_validate.c:54: validate_one_region(0x20000000, 0x1800) > 0
  WARN: Task 'worker' region 'r' size 0x1800 not power-of-2
```

— the WARN prints, and the function still returns 0.

## Verification

| | |
|---|---|
| `ctest --no-tests=error` | **27/29** |
| new suite | 6/6 |

The two `Not Run` are `test_os_adapter` and `test_os_services`, which need `services/compat` — that does not build on macOS (`pthread_mutex_timedlock` / `sem_timedwait`), **#96's subject**, not this one.

**Stacked on #102**, which repairs the macOS HAL link.
