### PR TITLE
test: register four suites that existed but were never built

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -182,6 +182,47 @@ add_executable(test_devicetree test_devicetree.c)
 target_link_libraries(test_devicetree PRIVATE eos_devicetree)
 add_test(NAME test_devicetree COMMAND test_devicetree)
 
+
+# ---------------------------------------------------------------------------
+# Suites that existed in tests/ but were never registered.
+#
+# Each of these has a main() and compiles; none was in any add_executable(),
+# so CI never built or ran them. test_crypto_failclosed.c is the one that
+# matters most -- it asserts that the stub RSA/ECC routines refuse to run,
+# written after a 256-byte file with the right trailing bytes made secure
+# boot report VERIFIED for an arbitrary image. A regression guard that is
+# never executed is exactly the failure it was written to prevent.
+# ---------------------------------------------------------------------------
+add_executable(test_crypto_failclosed test_crypto_failclosed.c)
+target_link_libraries(test_crypto_failclosed PRIVATE eos_crypto)
+add_test(NAME test_crypto_failclosed COMMAND test_crypto_failclosed)
+
+add_executable(test_crc test_crc.c)
+target_link_libraries(test_crc PRIVATE eos_crypto)
+add_test(NAME test_crc COMMAND test_crc)
+
+add_executable(test_driver_recovery test_driver_recovery.c)
+target_link_libraries(test_driver_recovery PRIVATE eos_drivers)
+add_test(NAME test_driver_recovery COMMAND test_driver_recovery)
+
+# test_net_integration.c is deliberately NOT registered. It hangs.
+#
+# test_accept_no_client() asserts that eos_net_accept() returns
+# EOS_SOCKET_INVALID with no client pending -- its own comment says
+# "No connection pending in stub". That was true of the net.c stub, which
+# returned INVALID unconditionally. Since the POSIX implementation landed,
+# accept() on a blocking listening socket waits for a connection that
+# never arrives, so the suite never returns.
+#
+# eos_net_accept() takes no timeout and there is no non-blocking option in
+# the API, so the test cannot simply be retimed: either it grows a client
+# to accept, or the API grows a way to poll. That is a design decision,
+# not a registration, so it is left out here rather than bundled in.
+
+add_executable(test_stress test_stress.c)
+target_link_libraries(test_stress PRIVATE eos_kernel)
+add_test(NAME test_stress COMMAND test_stress)
+
 # --- Fuzz targets ---
 # Opt-in (-DEOS_ENABLE_FUZZING=ON, Clang only); the subdirectory guards itself.
 add_subdirectory(fuzz)


### PR DESCRIPTION
`tests/` holds 42 test files. **Twelve are in no `add_executable()`**, so CI has never compiled or run them. Four build and pass as they stand and are registered here.

## The one that matters

`test_crypto_failclosed.c` asserts that the stub RSA and ECC routines refuse to run. Its own header says why it exists:

> `eos_rsa_verify_sha256()` compared only the trailing 32 bytes of the signature against the hash, and `eos_ecc_verify()` returned success for any 64-byte input; **neither read the key**. That was reachable from `eos_secureboot_verify_image()`, so a 256-byte file whose last 32 bytes were an image's own SHA-256 — producible with no private key — made secure boot report VERIFIED for an arbitrary image.
> …
> These tests assert that refusal, **so the bypass cannot come back unnoticed.**

**A regression guard that is never executed is precisely the failure it was written to prevent.** It passes today; now it will keep saying so.

Also registered: `test_crc`, `test_driver_recovery`, `test_stress`.

```
ctest: 29 → 33, all passing
```

## Deliberately not registered: test_net_integration.c

**It hangs.** `test_accept_no_client()` asserts `eos_net_accept()` returns `EOS_SOCKET_INVALID` with no client pending, and its own comment says *"No connection pending in stub"* — true of the `net.c` stub, which returned `INVALID` unconditionally.

Since the POSIX implementation landed, `accept()` on a blocking listening socket waits for a connection that never arrives:

```
test_net_integration        HANGS (>15s)
```

`eos_net_accept()` takes no timeout and the API has no non-blocking option, so this cannot just be retimed — either the test grows a client to accept, or the API grows a way to poll. That is a design decision, so it is left out with the reasoning recorded in `tests/CMakeLists.txt` rather than folded into a registration PR.

Worth flagging on its own: it is a test written against stub semantics that the real implementation no longer has, and nothing caught the drift because the test was never built.

## Not touched

The remaining seven — `test_e2e`, `test_emulation_simulation`, `test_firmware`, `test_hal_stm32f4`, `test_net_mock`, `test_performance_benchmarks`, `test_profiles` — need more than a link line. Left for follow-up rather than half-done here.

## Verification

`ctest --no-tests=error` on current master: **33/33**.
