### PR TITLE
fix(tests): include assert.h in test_net.c, which master no longer builds

### DIFF
--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## master does not compile

```
tests/test_net.c:212:5: error: call to undeclared function 'assert';
  ISO C99 and later do not support implicit function declarations
tests/test_net.c:232:5: error: ...
tests/test_net.c:249:5: error: ...
```

`test_net.c` makes ten `assert()` calls and includes `stdio.h`, `stdlib.h` and `string.h` — but never `assert.h`.

It built while every test target was compiled with `NDEBUG`. #104 removed that from test targets so the assertions in these suites are real again, and that is what turned the missing include into a hard error. The omission was always there; #104 made the compiler care.

## Fix

Add the include. Nothing else changes.

I swept the rest of `tests/*.c` — this is the only file that calls `assert()` without including the header:

```
$ for f in $(grep -rl "assert(" tests/*.c); do
    grep -q "include <assert.h>" $f || echo "MISSING: $f"; done
MISSING: tests/test_net.c
```

## Verified

```
$ cmake --build build -j8      # was: 3 errors
BUILD OK
$ ctest
100% tests passed, 34 of 34
```

and the assertions are genuinely live rather than compiled away — the binary still carries its `test_net.c` assertion strings, which is the guarantee #104 exists to provide.
