### PR TITLE
fix(net): guard net_posix.c, which broke every non-test build

### DIFF
--- a/net/src/net_posix.c
+++ b/net/src/net_posix.c
@@ -25,6 +25,15 @@
 
 #include "eos/net.h"
 
+/* eos/net.h puts every eNet declaration behind EOS_ENABLE_NET, but this
+ * file is in eos_net's source list unconditionally. Built without the
+ * feature -- which is the default configuration, since CMakeLists.txt only
+ * defines EOS_ENABLE_NET for the test build -- the header contributed no
+ * types and every definition below failed with "unknown type name
+ * eos_socket_t". Guarding the body compiles it away instead, which is what
+ * a disabled feature is supposed to do. */
+#if EOS_ENABLE_NET
+
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -203,3 +212,5 @@ int eos_net_resolve(const char *hostname, uint32_t *ip)
     freeaddrinfo(res);
     return 0;
 }
+
+#endif /* EOS_ENABLE_NET */

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
> Stacked on #112. Review the last commit.

## The default build does not compile

```
$ cmake -S . -B build && cmake --build build
net/src/net_posix.c:43:30: error: unknown type name 'eos_net_addr_t'
net/src/net_posix.c:73:1:  error: unknown type name 'eos_socket_t'
... 30 more
```

This is what the library job in `CI — eos` runs, and it is failing on master for this reason.

## Why

`eos/net.h` puts every eNet declaration behind `#if EOS_ENABLE_NET`. `CMakeLists.txt` defines that flag only under:

```cmake
if(EOS_BUILD_TESTS AND NOT EOS_PRODUCT)
    add_compile_definitions(... EOS_ENABLE_NET=1 ...)
```

but `net/src/net_posix.c` is in `eos_net`'s source list **unconditionally**. Built without the feature, the header contributes no types and every definition in the file fails.

That is also why it stays invisible locally: `-DEOS_BUILD_TESTS=ON` is what anyone running the suite passes, and it happens to be the one configuration that defines the flag.

## Fix

Guard the body the way the header is guarded, so the translation unit compiles away when the feature is off — what a disabled feature is supposed to do — rather than failing to compile.

## Verified in both configurations

```
$ cmake -S . -B build && cmake --build build          # was: 32 errors
default build OK

$ cmake -S . -B build -DEOS_BUILD_TESTS=ON && ctest
100% tests passed, 34 of 34

$ nm libeos_net.a | grep -c eos_net_socket
1                                                      # still linked when the feature is on
```
