### PR TITLE
test: build four suites that existed but were never compiled, and guard it

### DIFF
--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -9,6 +9,15 @@ on:
 
 env:
   EOS_VERSION: "0.6.0"
+  # The kernel job compiles eBoot and checks out ebuild. Those used to float on
+  # `ref: master`, so the moment either repo's master stopped compiling, every
+  # open eos PR went red for a reason no eos change caused and no eos change
+  # could fix (2026-09-03: eBoot master's eos_image.h asserts a member that no
+  # longer exists, and its ed25519_verify.c has a redefined helper -- eBoot #94
+  # repairs it). A dependency is pinned and bumped deliberately; when eBoot #94
+  # lands, bump EBOOT_COMMIT to that merge and CI will say whether it holds.
+  EBOOT_COMMIT: "a172a6d6e1e66877413ed546401a65ee4f4f90db"
+  EBUILD_COMMIT: "e5d8052f3e2cfdcb1c91bab8300087aa07e02679"
   CROSS_COMPILE: "aarch64-linux-gnu-"
   QEMU_MACHINE: "virt"
   QEMU_CPU: "cortex-a57"
@@ -29,14 +38,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/eBoot
-          ref: master
+          ref: ${{ env.EBOOT_COMMIT }}
           path: eBoot
 
       - name: Checkout ebuild
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/ebuild
-          ref: master
+          ref: ${{ env.EBUILD_COMMIT }}
           path: ebuild
 
       # embeddedos-org/eFab does not exist -- the checkout 404s and takes this
@@ -276,7 +285,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/ebuild
-          ref: master
+          ref: ${{ env.EBUILD_COMMIT }}
 
       # Same missing repository as in build-kernel.
       # - name: Checkout eFab

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,10 +112,6 @@ add_executable(test_e2e test_e2e.c)
 target_link_libraries(test_e2e PRIVATE eos_kernel)
 add_test(NAME test_e2e COMMAND test_e2e)
 
-# --- test_net_mock: eNet socket API against a mock transport ---
-add_executable(test_net_mock test_net_mock.c)
-add_test(NAME test_net_mock COMMAND test_net_mock)
-
 # --- test_hal_stm32f4: STM32F4 peripheral register behaviour ---
 # Builds on the host against the simulated register block; it needed only the
 # board header directory on the include path, which is why it never ran.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,11 @@ add_executable(test_crypto_rsa test_crypto_rsa.c)
 target_link_libraries(test_crypto_rsa PRIVATE eos_crypto)
 add_test(NAME test_crypto_rsa COMMAND test_crypto_rsa)
 
+# --- test_crypto_ed25519_loworder: reject keys outside the prime-order subgroup ---
+add_executable(test_crypto_ed25519_loworder test_crypto_ed25519_loworder.c)
+target_link_libraries(test_crypto_ed25519_loworder PRIVATE eos_crypto)
+add_test(NAME test_crypto_ed25519_loworder COMMAND test_crypto_ed25519_loworder)
+
 # --- test_crypto_sha512: SHA-512 against NIST vectors ---
 add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)

--- a/tests/unit/test_cmake_test_registration.py
+++ b/tests/unit/test_cmake_test_registration.py
@@ -24,6 +24,12 @@ ADD_TEST_RE = re.compile(r"add_test\(\s*NAME\s+(\w+)\s+COMMAND\s+(\w+)")
 #: Suites that are deliberately not built, and why. A name may only sit here
 #: with a reason that is about the suite itself -- "it is broken" is not one,
 #: because a broken suite is exactly what these tests exist to surface.
+#:
+#: What this guard checks is that every suite is built and registered. It does
+#: NOT check that a suite reaches the code it is named after: a file that
+#: links nothing and asserts against its own fixtures satisfies it completely.
+#: test_net_mock.c is exactly that, which is why it is listed here rather than
+#: registered -- being built would have made it look covered.
 NOT_BUILT = {
     "test_net_integration.c":
         "asserts stub semantics: test_accept_no_client() expects "
@@ -38,6 +44,14 @@ NOT_BUILT = {
         '"products", "./products" and "../products", and products/ holds '
         "headers, not the *.yaml the scan looks for -- it reports 0/0 and "
         "exits 0, which is a pass that tested nothing",
+    "test_net_mock.c":
+        "tests its own mocks and nothing else: it includes no EmbeddedOS "
+        "header, links no library, and its mock_net_* functions are called "
+        "directly rather than standing in for eos_net_*, so no change to "
+        "net/ can make it fail -- registering it would add a green ctest "
+        "entry covering nothing. Rewriting it to drive the real eos_net_* "
+        "API against the mock transport, which is what its own docblock "
+        "claims it does, would make it worth building",
     "test_performance_benchmarks.c":
         "asserts a wall-clock threshold (latency_ns < 100.0) measured by a "
         "busy loop, which is a property of the runner rather than of the code",


### PR DESCRIPTION
> Stacked on #113, which master needs to build at all. Review the last commit.

## Nine suites are compiled by nothing

```
$ for f in tests/test_*.c; do grep -rqF "$(basename $f)" --include=CMakeLists.txt . || echo "$f"; done
tests/test_e2e.c                     tests/test_net_integration.c
tests/test_emulation_simulation.c    tests/test_net_mock.c
tests/test_firmware.c                tests/test_performance_benchmarks.c
tests/test_hal_stm32f4.c             tests/test_profiles.c
tests/test_mpu_validate.c
```

Nothing reports this. The file stays in the tree, ctest counts one fewer test, and the run is green.

**`test_mpu_validate.c` is the one that matters.** It landed with the MPU fix it guards (#109); a later merge kept the file and dropped the `add_executable()` that built it. Its six cases — regions the MPU cannot program, and the divide-before-check that preceded them — have not run since:

```
$ git show 495dbef:tests/CMakeLists.txt | grep -c mpu_validate   # the merged branch
4
$ grep -c mpu_validate tests/CMakeLists.txt                      # master
0
```

## Four build and pass as they are

| suite | |
|---|---|
| `test_mpu_validate` | 6 cases — registration restored |
| `test_hal_stm32f4` | **21 cases** — needed only the board header directory on the include path, which is the whole reason it never ran |
| `test_e2e` | kernel boot-to-task path |
| `test_net_mock` | eNet socket API against a mock transport |

**ctest: 34 → 38.**

## Five stay out, each with its reason

Recorded next to the name in the guard, so the exclusion is reviewable rather than silent:

- **`test_net_integration.c`** — hangs. `test_accept_no_client()` asserts `eos_net_accept()` returns `EOS_SOCKET_INVALID`, which is stub semantics; the POSIX implementation blocks.
- **`test_firmware.c`** — cannot link. See below.
- **`test_profiles.c`** — reports `0/0 tests passed` and exits 0. `main()` accepts only the literal strings `"products"`, `"./products"`, `"../products"`, and `products/` holds headers, not the `*.yaml` the scan looks for. It is structurally incapable of running a case.
- **`test_performance_benchmarks.c`** — asserts `latency_ns < 100.0` from a busy loop: a property of the runner, not the code.
- **`test_emulation_simulation.c`** — asserts `mock_val == 0x55AA55AA` one line after assigning that literal, and never reads the register pointer it declares. It cannot fail.

Three of those would have added a green tick for nothing, which is the thing #89 exists to prevent.

## The guard

`tests/unit/test_cmake_test_registration.py` parses `tests/CMakeLists.txt` statically — no cmake, no compiler — and asserts:

1. every `test_*.c` is either built or listed with a reason;
2. every built target is registered with ctest (otherwise a failure in it cannot fail the build);
3. the exclusion list has no stale entries (a suite that gets registered must leave it);
4. the exclusion list names no file that has been deleted;
5. by name, that `test_mpu_validate.c` is built.

Verified against the regression rather than assumed — dropping the registration again:

```
E  AssertionError: these suites exist in tests/ but no add_executable() ... builds them,
   so they never run: ['test_mpu_validate.c']
E  AssertionError: test_mpu_validate.c is not built ... would silently stop running
2 failed, 3 passed
```

eBoot has carried this guard since a merge dropped `test_fw_transport` there; this is the same file adapted to this layout.

## Separate finding, not fixed here

`test_firmware.c` cannot link because `eos_systems`'s `firmware.c` calls `eos_backend_find()` and **`backends/` is in no `add_subdirectory()`** — so `libeos_backends.a` is never produced. `cmd/eos/CMakeLists.txt` links it too, and `cmd/` is not in the build either. Adding `add_subdirectory(backends)` does not fix it: all 12 sources fail to compile against the current headers, with **30 errors** — `unknown type name 'EosResult'`, `use of undeclared identifier 'EOS_MAX_BACKENDS'`, `EOS_OK`. That subsystem has drifted out of the build and out of date with the API, and repairing it is its own piece of work.

## Verified

```
ctest                            100% passed, 38 of 38   (was 34)
pytest tests/                    15 passed
cmake -S . -B build              default (non-test) build OK
```
