### PR TITLE
fix(pkg): give eos_pkg a real trust anchor, or refuse to verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **`eos_pkg` trust anchor:** Package signatures were checked against `eos_pkg_public_key[32] = {0}`. #99 stopped that all-zero key accepting every package, which left it rejecting every package -- including correctly signed ones -- while reporting `signature verification failed`, blaming the package for a key that was never provisioned. The key now comes from `eos_pkg_set_trust_anchor()` or from `EOS_PKG_TRUST_ANCHOR_HEX` at build time; with neither, verification refuses and says so, unless the build defines `EOS_ALLOW_UNSIGNED_PKG`. Closes the second half of #98.
+- **`services/pkg` is compiled.** `services/pkg/eos_pkg.c` was in no `CMakeLists.txt`, so no target built it and no test could reach it -- which is how the all-zero anchor survived. It is now the `eos_eapp` library, with `tests/test_pkg_trust_anchor.c` covering it.
+- **`ed25519_public_key_is_usable()`:** #99's subgroup and identity checks are exported, so a stored trust anchor can be rejected when it is configured rather than once per package as an apparent signature failure.
 - **`eos_queue_send` / `eos_queue_receive`:** A full send/recv waiter table now returns `EOS_KERN_NO_MEMORY` instead of blocking a task that can never be woken, matching mutex and semaphore behavior.
 - **`eos_queue_create`:** Size check now uses division so `item_size * capacity` cannot wrap `size_t` on 32-bit targets and overflow the 1024-byte queue store.
 - **`eos_sem_create`:** Reject `initial > max` and `max` values that do not fit in `int32_t`, so the counting-semaphore invariant cannot be created already broken.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,13 @@ add_subdirectory(systems)
 # Services — crypto, security, os, linux, rtos, sensor, motor, ota, fs
 # ====================================================================
 add_subdirectory(services)
-add_subdirectory(services/pkg)
+# services/pkg is the host-side .eapp package manager: it lists directories,
+# spawns processes and waits on them, so it needs <dirent.h>, <unistd.h> and
+# <sys/wait.h>. Bare-metal newlib has none of those -- <dirent.h> is a hard
+# #error there -- so it is host-only, gated the same way net_posix.c is.
+if(NOT CMAKE_CROSSCOMPILING)
+    add_subdirectory(services/pkg)
+endif()
 add_subdirectory(pkg)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ add_subdirectory(systems)
 # Services — crypto, security, os, linux, rtos, sensor, motor, ota, fs
 # ====================================================================
 add_subdirectory(services)
+add_subdirectory(services/pkg)
 add_subdirectory(pkg)
 
 

--- a/net/src/net_posix.c
+++ b/net/src/net_posix.c
@@ -34,6 +34,15 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+/* net.h wraps its declarations in #if EOS_ENABLE_NET, but CMake adds this
+ * file to eos_net on every non-cross build regardless of that flag. With no
+ * product profile and no test build nothing sets it, so the header expanded to
+ * nothing while this file still defined the API against it -- `unknown type
+ * name 'eos_net_addr_t'`, and the default configuration stopped compiling.
+ * net.c already carries this guard; the POSIX mapping needs the same one so
+ * both translation units appear and disappear together. */
+#if EOS_ENABLE_NET
+
 /* eos_socket_t is an int and EOS_SOCKET_INVALID is -1, which is exactly what
  * socket(2) returns on failure, so the fd is the handle. No table, no
  * translation, and no way for the two to drift. */
@@ -203,3 +212,5 @@ int eos_net_resolve(const char *hostname, uint32_t *ip)
     freeaddrinfo(res);
     return 0;
 }
+
+#endif /* EOS_ENABLE_NET */

--- a/services/crypto/include/ed25519.h
+++ b/services/crypto/include/ed25519.h
@@ -27,6 +27,11 @@ int ED25519_DECLSPEC ed25519_create_seed(unsigned char *seed);
 void ED25519_DECLSPEC ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
 void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
 int ED25519_DECLSPEC ed25519_verify(const unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key);
+
+/* Non-zero if public_key decodes to a point of prime order, i.e. if it can
+ * authenticate anything. Use it to validate a stored trust anchor when it is
+ * configured; ed25519_verify() applies the same rule per signature. */
+int ED25519_DECLSPEC ed25519_public_key_is_usable(const unsigned char *public_key);
 void ED25519_DECLSPEC ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void ED25519_DECLSPEC ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);
 

--- a/services/crypto/src/ed25519_verify.c
+++ b/services/crypto/src/ed25519_verify.c
@@ -112,6 +112,27 @@ static int ed25519_key_has_prime_order(const ge_p3 *A) {
     /* A key of prime order L multiplies to the identity. */
     return ed25519_point_is_identity(packed);
 }
+
+/* Is this encoding usable as a trust anchor?
+ *
+ * ed25519_verify() runs the same two tests, but only once a signature is in
+ * hand, and a failure there is indistinguishable from a bad signature. A
+ * caller that stores a key -- eos_pkg's trust anchor, see #98 -- needs to ask
+ * about the key alone, at the moment it is configured, so an unusable anchor
+ * is reported as an unusable anchor rather than as a stream of packages that
+ * all appear to be forged.
+ */
+int ed25519_public_key_is_usable(const unsigned char *public_key) {
+    ge_p3 A;
+
+    if (public_key == 0) {
+        return 0;
+    }
+    if (ge_frombytes_negate_vartime(&A, public_key) != 0) {
+        return 0;
+    }
+    return ed25519_key_has_prime_order(&A);
+}
 int ed25519_verify(const unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key) {
     unsigned char h[64];
     unsigned char checker[32];

--- a/services/pkg/CMakeLists.txt
+++ b/services/pkg/CMakeLists.txt
@@ -1,0 +1,21 @@
+# The .eapp package manager. Nothing built this directory until now, which is
+# why its all-zero trust anchor survived: no target compiled the file, so no
+# test could reach it. See #98.
+#
+# The target is eos_eapp, not eos_pkg: pkg/ already claims that name for the
+# build-recipe package registry, a different module with a similar one.
+add_library(eos_eapp STATIC
+    eos_pkg.c
+)
+
+target_include_directories(eos_eapp PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(eos_eapp PUBLIC eos_crypto)
+
+target_compile_options(eos_eapp PRIVATE
+    $<$<C_COMPILER_ID:GNU>:-Wall -Wextra -Wpedantic>
+    $<$<C_COMPILER_ID:Clang>:-Wall -Wextra -Wpedantic>
+    $<$<C_COMPILER_ID:MSVC>:/W4>
+)

--- a/services/pkg/eos_pkg.c
+++ b/services/pkg/eos_pkg.c
@@ -89,9 +89,155 @@ static int eos_rmdir_recursive(const char *path)
 #include <eos/crypto.h>
 #include <ed25519.h>
 
-// Temporary hardcoded public key for package verification.
-// In a real system, this should be loaded from a secure keystore.
-static const uint8_t eos_pkg_public_key[32] = {0};
+/* --------------------------------------------------------------------------
+ * Trust anchor
+ *
+ * This file used to carry
+ *
+ *     static const uint8_t eos_pkg_public_key[32] = {0};
+ *
+ * with a comment saying a real system would load it from a keystore. The
+ * all-zero encoding is one of Ed25519's eight low-order points, so before
+ * services/crypto learned to reject those (#99) every package verified. It
+ * now rejects every package instead -- including correctly signed ones --
+ * and reports "signature verification failed", which blames the package for
+ * a defect in the installation.
+ *
+ * Neither behaviour is a signature check. A key is required, and there is
+ * nowhere in this repository it can honestly be hardcoded from, so it comes
+ * from the platform instead:
+ *
+ *   1. eos_pkg_set_trust_anchor(), which is where a keystore or a
+ *      provisioning step installs the key it holds; or
+ *   2. EOS_PKG_TRUST_ANCHOR_HEX, 64 hex characters set by the build.
+ *
+ * With neither, verification refuses rather than appearing to succeed. That
+ * is the shape services/crypto already uses for its unimplemented RSA/ECC
+ * stubs (EOS_ALLOW_STUB_CRYPTO) and services/ota for an update with no
+ * authenticator installed (EOS_ALLOW_UNSIGNED_OTA); EOS_ALLOW_UNSIGNED_PKG
+ * is the same opt-in, for tests and for bring-up.
+ * -------------------------------------------------------------------------- */
+
+static uint8_t  eos_pkg_anchor[EAPP_PUBKEY_LEN];
+static bool     eos_pkg_anchor_set = false;
+
+#ifdef EOS_PKG_TRUST_ANCHOR_HEX
+static int eos_pkg_hex_nibble(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/* Decode the build-time anchor. A malformed value is a build configuration
+ * error, so it is refused rather than truncated or padded. */
+static bool eos_pkg_anchor_from_build(uint8_t out[EAPP_PUBKEY_LEN])
+{
+    static const char hex[] = EOS_PKG_TRUST_ANCHOR_HEX;
+    size_t i;
+
+    if (sizeof(hex) - 1 != EAPP_PUBKEY_LEN * 2) {
+        fprintf(stderr,
+                "eos-pkg: EOS_PKG_TRUST_ANCHOR_HEX is %zu characters, "
+                "expected %d\n", sizeof(hex) - 1, EAPP_PUBKEY_LEN * 2);
+        return false;
+    }
+    for (i = 0; i < EAPP_PUBKEY_LEN; i++) {
+        int hi = eos_pkg_hex_nibble(hex[i * 2]);
+        int lo = eos_pkg_hex_nibble(hex[i * 2 + 1]);
+        if (hi < 0 || lo < 0) {
+            fprintf(stderr, "eos-pkg: EOS_PKG_TRUST_ANCHOR_HEX is not hex\n");
+            return false;
+        }
+        out[i] = (uint8_t)((hi << 4) | lo);
+    }
+    return true;
+}
+#endif
+
+int eos_pkg_set_trust_anchor(const uint8_t public_key[EAPP_PUBKEY_LEN])
+{
+    if (!public_key) {
+        eos_pkg_anchor_set = false;
+        memset(eos_pkg_anchor, 0, sizeof(eos_pkg_anchor));
+        return 0;
+    }
+
+    /* Refuse the key here, where the caller is configuring it and can act on
+     * the answer. Accepting it and failing later turns a provisioning mistake
+     * into a package that looks forged. */
+    if (!ed25519_public_key_is_usable(public_key)) {
+        fprintf(stderr,
+                "eos-pkg: refusing a trust anchor that is not a prime-order "
+                "Ed25519 point; such a key cannot authenticate anything\n");
+        return -1;
+    }
+
+    memcpy(eos_pkg_anchor, public_key, EAPP_PUBKEY_LEN);
+    eos_pkg_anchor_set = true;
+    return 0;
+}
+
+const uint8_t *eos_pkg_trust_anchor(void)
+{
+    if (eos_pkg_anchor_set) return eos_pkg_anchor;
+
+#ifdef EOS_PKG_TRUST_ANCHOR_HEX
+    {
+        uint8_t built[EAPP_PUBKEY_LEN];
+        if (eos_pkg_anchor_from_build(built) &&
+            ed25519_public_key_is_usable(built)) {
+            memcpy(eos_pkg_anchor, built, EAPP_PUBKEY_LEN);
+            eos_pkg_anchor_set = true;
+            return eos_pkg_anchor;
+        }
+        fprintf(stderr,
+                "eos-pkg: EOS_PKG_TRUST_ANCHOR_HEX does not decode to a "
+                "usable Ed25519 public key\n");
+    }
+#endif
+    return NULL;
+}
+
+/* Check a package signature against the configured anchor.
+ *
+ * Returns 0 when the signature is good, -1 otherwise. The three failures are
+ * reported apart because they call for different actions: fix the
+ * provisioning, fix the build, or reject the package.
+ */
+static int eos_pkg_check_signature(const uint8_t signature[EAPP_SIGNATURE_LEN],
+                                   const uint8_t *binary_data,
+                                   uint32_t binary_size)
+{
+    const uint8_t *anchor = eos_pkg_trust_anchor();
+
+    if (!anchor) {
+#ifdef EOS_ALLOW_UNSIGNED_PKG
+        fprintf(stderr,
+                "eos-pkg: WARNING: no trust anchor configured and this build "
+                "defines EOS_ALLOW_UNSIGNED_PKG; the package is NOT "
+                "authenticated\n");
+        (void)signature; (void)binary_data; (void)binary_size;
+        return 0;
+#else
+        fprintf(stderr,
+                "eos-pkg: refusing to verify: no trust anchor is configured. "
+                "The SHA-256 in the header travels with the package and says "
+                "nothing about its origin. Install a key with "
+                "eos_pkg_set_trust_anchor(), build with "
+                "EOS_PKG_TRUST_ANCHOR_HEX, or -- for tests only -- with "
+                "EOS_ALLOW_UNSIGNED_PKG.\n");
+        return -1;
+#endif
+    }
+
+    if (!ed25519_verify(signature, binary_data, binary_size, anchor)) {
+        fprintf(stderr, "eos-pkg: signature verification failed\n");
+        return -1;
+    }
+    return 0;
+}
 
 static void eos_print_capabilities(uint32_t caps)
 {
@@ -371,8 +517,7 @@ int eos_pkg_verify(const char *eapp_path)
         return -1;
     }
 
-    if (!ed25519_verify(hdr.signature, binary_data, hdr.binary_size, eos_pkg_public_key)) {
-        fprintf(stderr, "eos-pkg: signature verification failed\n");
+    if (eos_pkg_check_signature(hdr.signature, binary_data, hdr.binary_size) != 0) {
         free(binary_data);
         fclose(f);
         return -1;
@@ -484,8 +629,7 @@ int eos_pkg_install(eapp_db_t *db, const char *eapp_path)
         return -1;
     }
 
-    if (!ed25519_verify(hdr.signature, binary_data, hdr.binary_size, eos_pkg_public_key)) {
-        fprintf(stderr, "eos-pkg: signature verification failed\n");
+    if (eos_pkg_check_signature(hdr.signature, binary_data, hdr.binary_size) != 0) {
         free(binary_data);
         fclose(f);
         return -1;

--- a/services/pkg/eos_pkg.h
+++ b/services/pkg/eos_pkg.h
@@ -11,6 +11,7 @@
 #define EAPP_MAX_PATH       256
 #define EAPP_MAX_PACKAGES   64
 #define EAPP_SIGNATURE_LEN  64  /* Ed25519 */
+#define EAPP_PUBKEY_LEN     32  /* Ed25519 public key */
 #define EAPP_HASH_LEN       32  /* SHA-256 */
 
 /* Package capabilities */
@@ -139,6 +140,32 @@ int  eos_pkg_update(eapp_db_t *db, const char *eapp_path);
 int  eos_pkg_list(const eapp_db_t *db);
 int  eos_pkg_info(const eapp_db_t *db, const char *package_id);
 int  eos_pkg_verify(const char *eapp_path);
+
+/**
+ * @brief Install the Ed25519 public key that package signatures are checked
+ *        against, or NULL to remove it.
+ *
+ * This is the seam a keystore or a provisioning step fills; there is no key
+ * that can honestly be compiled into this repository. The key is validated
+ * here rather than at verification time -- a key outside the prime-order
+ * subgroup authenticates nothing, and reporting that as "signature
+ * verification failed" per package blames the package for a defect in the
+ * installation.
+ *
+ * @return 0 if the key was installed, -1 if it is unusable as an anchor.
+ */
+int  eos_pkg_set_trust_anchor(const uint8_t public_key[EAPP_PUBKEY_LEN]);
+
+/**
+ * @brief The anchor in force: the one set at runtime, else the one the build
+ *        supplied via EOS_PKG_TRUST_ANCHOR_HEX, else NULL.
+ *
+ * With no anchor, eos_pkg_verify() and eos_pkg_install() refuse rather than
+ * appear to verify, unless the build defines EOS_ALLOW_UNSIGNED_PKG. That
+ * mirrors EOS_ALLOW_STUB_CRYPTO in services/crypto and EOS_ALLOW_UNSIGNED_OTA
+ * in services/ota.
+ */
+const uint8_t *eos_pkg_trust_anchor(void);
 int  eos_pkg_run(const eapp_db_t *db, const char *package_id, int argc, char **argv);
 int  eos_pkg_stop(const eapp_db_t *db, const char *package_id);
 int  eos_pkg_enable(eapp_db_t *db, const char *package_id);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,11 @@ if(UNIX AND NOT APPLE)
 endif()
 add_test(NAME test_motor_ctrl COMMAND test_motor_ctrl)
 
+# --- test_pkg_trust_anchor: eos_pkg refuses to verify without a real key ---
+add_executable(test_pkg_trust_anchor test_pkg_trust_anchor.c)
+target_link_libraries(test_pkg_trust_anchor PRIVATE eos_eapp eos_crypto)
+add_test(NAME test_pkg_trust_anchor COMMAND test_pkg_trust_anchor)
+
 # --- test_package: Package management ---
 add_executable(test_package test_package.c)
 target_include_directories(test_package PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,31 @@ add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)
 add_test(NAME test_crypto_sha512 COMMAND test_crypto_sha512)
 
+# --- test_mpu_validate: MPU region programmability ---
+# Landed with the fix it guards (#109) and lost its registration to a merge,
+# so the six cases stopped being compiled while the file stayed in the tree.
+add_executable(test_mpu_validate test_mpu_validate.c)
+target_link_libraries(test_mpu_validate PRIVATE eos_rtos_security)
+add_test(NAME test_mpu_validate COMMAND test_mpu_validate)
+
+# --- test_e2e: kernel boot-to-task end-to-end path ---
+add_executable(test_e2e test_e2e.c)
+target_link_libraries(test_e2e PRIVATE eos_kernel)
+add_test(NAME test_e2e COMMAND test_e2e)
+
+# --- test_net_mock: eNet socket API against a mock transport ---
+add_executable(test_net_mock test_net_mock.c)
+add_test(NAME test_net_mock COMMAND test_net_mock)
+
+# --- test_hal_stm32f4: STM32F4 peripheral register behaviour ---
+# Builds on the host against the simulated register block; it needed only the
+# board header directory on the include path, which is why it never ran.
+add_executable(test_hal_stm32f4 test_hal_stm32f4.c)
+target_include_directories(test_hal_stm32f4 PRIVATE
+    ${CMAKE_SOURCE_DIR}/boards/stm32f407_discovery)
+target_link_libraries(test_hal_stm32f4 PRIVATE eos_hal)
+add_test(NAME test_hal_stm32f4 COMMAND test_hal_stm32f4)
+
 # --- test_security: Keystore, ACL ---
 add_executable(test_security test_security.c)
 target_link_libraries(test_security PRIVATE eos_security eos_crypto)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,9 +218,13 @@ endif()
 add_test(NAME test_motor_ctrl COMMAND test_motor_ctrl)
 
 # --- test_pkg_trust_anchor: eos_pkg refuses to verify without a real key ---
-add_executable(test_pkg_trust_anchor test_pkg_trust_anchor.c)
-target_link_libraries(test_pkg_trust_anchor PRIVATE eos_eapp eos_crypto)
-add_test(NAME test_pkg_trust_anchor COMMAND test_pkg_trust_anchor)
+# eos_eapp exists only in a host build; see the comment on services/pkg in the
+# top-level CMakeLists.txt.
+if(NOT CMAKE_CROSSCOMPILING)
+    add_executable(test_pkg_trust_anchor test_pkg_trust_anchor.c)
+    target_link_libraries(test_pkg_trust_anchor PRIVATE eos_eapp eos_crypto)
+    add_test(NAME test_pkg_trust_anchor COMMAND test_pkg_trust_anchor)
+endif()
 
 # --- test_package: Package management ---
 add_executable(test_package test_package.c)

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -209,17 +209,17 @@ static void test_net_tcp_round_trip(void) {
         ts.tv_nsec = 5 * 1000 * 1000;
         nanosleep(&ts, NULL);
     }
-    assert(ready == 1);
+    CHECK(ready == 1);
     eos_socket_t c = eos_net_socket(EOS_NET_TCP);
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = g_test_port;
-    assert(eos_net_connect(c, &addr) == 0);
-    assert(eos_net_send(c, "ping", 4) == 4);
+    CHECK(eos_net_connect(c, &addr) == 0);
+    CHECK(eos_net_send(c, "ping", 4) == 4);
     char buf[32];
     memset(buf, 0, sizeof(buf));
-    assert(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
-    assert(strcmp(buf, "ping") == 0);
+    CHECK(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
+    CHECK(strcmp(buf, "ping") == 0);
     eos_net_close(c);
     pthread_join(t, NULL);
     eos_net_deinit();
@@ -229,13 +229,13 @@ static void test_net_tcp_round_trip(void) {
 static void test_net_resolve_localhost(void) {
     eos_net_init();
     uint32_t ip = 0;
-    assert(eos_net_resolve("localhost", &ip) == 0);
-    assert(ip == inet_addr("127.0.0.1"));
+    CHECK(eos_net_resolve("localhost", &ip) == 0);
+    CHECK(ip == inet_addr("127.0.0.1"));
     /* A name that cannot resolve must fail rather than reporting success and
      * leaving the caller with whatever was in the output already. */
     uint32_t before = ip;
-    assert(eos_net_resolve("no.such.host.invalid", &ip) == -1);
-    assert(ip == before);
+    CHECK(eos_net_resolve("no.such.host.invalid", &ip) == -1);
+    CHECK(ip == before);
     eos_net_deinit();
     PASS("net resolve localhost");
 }
@@ -246,7 +246,7 @@ static void test_net_connect_refused(void) {
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = 1;              /* nothing listens on port 1 */
-    assert(eos_net_connect(c, &addr) != 0);
+    CHECK(eos_net_connect(c, &addr) != 0);
     eos_net_close(c);
     eos_net_deinit();
     PASS("net connect to a closed port fails");

--- a/tests/test_pkg_trust_anchor.c
+++ b/tests/test_pkg_trust_anchor.c
@@ -1,0 +1,250 @@
+/* SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 EoS Project
+ *
+ * @file test_pkg_trust_anchor.c
+ * @brief eos_pkg must have a real trust anchor, or refuse to verify.
+ *
+ * #99 taught services/crypto to reject low-order public keys, which closed the
+ * half of #98 where eos_pkg accepted every package. It left the other half:
+ * the anchor itself was still
+ *
+ *     static const uint8_t eos_pkg_public_key[32] = {0};
+ *
+ * so eos_pkg went from accepting everything to rejecting everything, and said
+ * "signature verification failed" while doing it -- blaming the package for a
+ * key that was never provisioned. A verifier that rejects a correctly signed
+ * package is not a working signature check either.
+ *
+ * The packages below are signed with RFC 8032 section 7.1 vectors, so they are
+ * genuinely signed by a real key and a test that only ever rejects is caught.
+ *
+ * Nothing compiled services/pkg/eos_pkg.c before this change -- it was in no
+ * CMakeLists -- which is why none of this was reachable by a test.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "eos_pkg.h"
+#include <eos/crypto.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define TEST(name) \
+    static void name(void); \
+    static void run_##name(void) { \
+        printf("  %-56s ", #name); \
+        fflush(stdout); \
+        name(); \
+        tests_passed++; \
+        printf("[PASS]\n"); \
+    } \
+    static void name(void)
+
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        printf("[FAIL] %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        exit(1); \
+    } \
+} while (0)
+
+/* ---- RFC 8032 section 7.1 ------------------------------------------------ */
+
+/* Test 2: a 1-byte message, so the package payload is the signed message. */
+static const uint8_t T2_PUB[32] = {
+ 0x3d,0x40,0x17,0xc3,0xe8,0x43,0x89,0x5a,0x92,0xb7,0x0a,0xa7,0x4d,0x1b,0x7e,0xbc,
+ 0x9c,0x98,0x2c,0xcf,0x2e,0xc4,0x96,0x8c,0xc0,0xcd,0x55,0xf1,0x2a,0xf4,0x66,0x0c};
+static const uint8_t T2_SIG[64] = {
+ 0x92,0xa0,0x09,0xa9,0xf0,0xd4,0xca,0xb8,0x72,0x0e,0x82,0x0b,0x5f,0x64,0x25,0x40,
+ 0xa2,0xb2,0x7b,0x54,0x16,0x50,0x3f,0x8f,0xb3,0x76,0x22,0x23,0xeb,0xdb,0x69,0xda,
+ 0x08,0x5a,0xc1,0xe4,0x3e,0x15,0x99,0x6e,0x45,0x8f,0x36,0x13,0xd0,0xf1,0x1d,0x8c,
+ 0x38,0x7b,0x2e,0xae,0xb4,0x30,0x2a,0xee,0xb0,0x0d,0x29,0x16,0x12,0xbb,0x0c,0x00};
+static const uint8_t T2_MSG[1] = { 0x72 };
+
+/* Test 1's key: a real, prime-order key that did not sign the package above. */
+static const uint8_t T1_PUB[32] = {
+ 0xd7,0x5a,0x98,0x01,0x82,0xb1,0x0a,0xb7,0xd5,0x4b,0xfe,0xd3,0xc9,0x64,0x07,0x3a,
+ 0x0e,0xe1,0x72,0xf3,0xda,0xa6,0x23,0x25,0xaf,0x02,0x1a,0x68,0xf7,0x07,0x51,0x1a};
+
+/* The eight low-order encodings. None can authenticate anything, so none is a
+ * usable anchor. The first is the value this file used to ship. */
+static const uint8_t LOW_ORDER[8][32] = {
+    /* y = 0, order 4 -- the encoding eos_pkg carried as its trust anchor */
+    {0},
+    /* the identity, order 1 */
+    {1},
+    /* order 8 */
+    {0x26,0xe8,0x95,0x8f,0xc2,0xb2,0x27,0xb0,0x45,0xc3,0xf4,0x89,0xf2,0xef,0x98,0xf0,
+     0xd5,0xdf,0xac,0x05,0xd3,0xc6,0x33,0x39,0xb1,0x38,0x02,0x88,0x6d,0x53,0xfc,0x05},
+    /* order 8 */
+    {0xc7,0x17,0x6a,0x70,0x3d,0x4d,0xd8,0x4f,0xba,0x3c,0x0b,0x76,0x0d,0x10,0x67,0x0f,
+     0x2a,0x20,0x53,0xfa,0x2c,0x39,0xcc,0xc6,0x4e,0xc7,0xfd,0x77,0x92,0xac,0x03,0x7a},
+    /* p - 1 */
+    {0xec,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+     0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f},
+    /* p, which reduces to y = 0 */
+    {0xed,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+     0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f},
+    /* p + 1, which reduces to the identity */
+    {0xee,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+     0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f},
+    /* non-canonical, above p */
+    {0xd9,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+     0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff},
+};
+
+/* ---- package construction ------------------------------------------------ */
+
+#define EAPP_PATH "test_trust_anchor.eapp"
+
+/* Write a structurally valid .eapp. The header hash is computed over the
+ * payload actually written, so the SHA-256 check always passes and every
+ * failure below is the signature check, never integrity. */
+static void write_eapp(const char *path,
+                       const uint8_t *payload, uint32_t payload_len,
+                       const uint8_t sig[64])
+{
+    eapp_header_t h;
+    FILE *f;
+    EosSha256 c;
+
+    memset(&h, 0, sizeof(h));
+    h.magic = EAPP_MAGIC;
+    h.version = EAPP_VERSION;
+    snprintf(h.name, sizeof(h.name), "%s", "trust-anchor-test");
+    snprintf(h.package_id, sizeof(h.package_id), "%s", "org.eos.test.anchor");
+    h.ver_major = 1;
+    h.arch_count = 1;
+    h.binary_offset = (uint32_t)sizeof(h);
+    h.binary_size = payload_len;
+    memcpy(h.signature, sig, EAPP_SIGNATURE_LEN);
+
+    eos_sha256_init(&c);
+    eos_sha256_update(&c, payload, payload_len);
+    eos_sha256_final(&c, h.hash);
+
+    f = fopen(path, "wb");
+    ASSERT(f != NULL);
+    ASSERT(fwrite(&h, sizeof(h), 1, f) == 1);
+    ASSERT(fwrite(payload, 1, payload_len, f) == payload_len);
+    fclose(f);
+}
+
+static void write_genuine_eapp(void)
+{
+    write_eapp(EAPP_PATH, T2_MSG, (uint32_t)sizeof(T2_MSG), T2_SIG);
+}
+
+/* ---- tests --------------------------------------------------------------- */
+
+TEST(test_no_anchor_refuses_a_genuine_package)
+{
+    /* The state this file shipped in, stated as a test: a package signed by a
+     * real key, refused. Before the fix this printed "signature verification
+     * failed" and the caller had no way to tell that the anchor, not the
+     * package, was the problem. */
+    ASSERT(eos_pkg_set_trust_anchor(NULL) == 0);
+    ASSERT(eos_pkg_trust_anchor() == NULL);
+
+    write_genuine_eapp();
+    ASSERT(eos_pkg_verify(EAPP_PATH) != 0);
+}
+
+TEST(test_low_order_keys_are_refused_as_anchors)
+{
+    /* Refused when configured, not when a package arrives. All eight, because
+     * the all-zero encoding this file used is only one of them and a fix aimed
+     * at that single value would leave the class open. */
+    size_t i;
+    for (i = 0; i < 8; i++) {
+        ASSERT(eos_pkg_set_trust_anchor(LOW_ORDER[i]) != 0);
+        ASSERT(eos_pkg_trust_anchor() == NULL);
+    }
+}
+
+TEST(test_a_real_key_is_accepted_as_an_anchor)
+{
+    const uint8_t *held;
+
+    ASSERT(eos_pkg_set_trust_anchor(NULL) == 0);
+    ASSERT(eos_pkg_set_trust_anchor(T2_PUB) == 0);
+
+    held = eos_pkg_trust_anchor();
+    ASSERT(held != NULL);
+    ASSERT(memcmp(held, T2_PUB, EAPP_PUBKEY_LEN) == 0);
+}
+
+TEST(test_a_genuine_package_verifies_under_its_own_key)
+{
+    /* Without this the tests above are satisfied by a verifier that rejects
+     * everything, which is the bug in its other form. */
+    ASSERT(eos_pkg_set_trust_anchor(T2_PUB) == 0);
+    write_genuine_eapp();
+    ASSERT(eos_pkg_verify(EAPP_PATH) == 0);
+}
+
+TEST(test_another_real_key_does_not_verify_the_package)
+{
+    ASSERT(eos_pkg_set_trust_anchor(T1_PUB) == 0);
+    write_genuine_eapp();
+    ASSERT(eos_pkg_verify(EAPP_PATH) != 0);
+}
+
+TEST(test_a_tampered_payload_is_rejected_by_the_signature)
+{
+    /* The header hash is recomputed over the tampered payload, so the SHA-256
+     * comparison passes and only the signature can reject this. That is the
+     * point: the hash travels with the package, so an attacker who replaces
+     * the payload replaces the hash too. */
+    static const uint8_t tampered[1] = { 0x73 };
+
+    ASSERT(eos_pkg_set_trust_anchor(T2_PUB) == 0);
+    write_eapp(EAPP_PATH, tampered, (uint32_t)sizeof(tampered), T2_SIG);
+    ASSERT(eos_pkg_verify(EAPP_PATH) != 0);
+}
+
+TEST(test_removing_the_anchor_restores_refusal)
+{
+    ASSERT(eos_pkg_set_trust_anchor(T2_PUB) == 0);
+    write_genuine_eapp();
+    ASSERT(eos_pkg_verify(EAPP_PATH) == 0);
+
+    ASSERT(eos_pkg_set_trust_anchor(NULL) == 0);
+    ASSERT(eos_pkg_trust_anchor() == NULL);
+    ASSERT(eos_pkg_verify(EAPP_PATH) != 0);
+}
+
+TEST(test_a_rejected_anchor_does_not_replace_the_one_in_force)
+{
+    /* A failed provisioning attempt must not disarm a working installation. */
+    ASSERT(eos_pkg_set_trust_anchor(T2_PUB) == 0);
+    ASSERT(eos_pkg_set_trust_anchor(LOW_ORDER[0]) != 0);
+
+    ASSERT(eos_pkg_trust_anchor() != NULL);
+    ASSERT(memcmp(eos_pkg_trust_anchor(), T2_PUB, EAPP_PUBKEY_LEN) == 0);
+
+    write_genuine_eapp();
+    ASSERT(eos_pkg_verify(EAPP_PATH) == 0);
+}
+
+int main(void)
+{
+    printf("eos_pkg trust anchor\n");
+
+    run_test_no_anchor_refuses_a_genuine_package();
+    run_test_low_order_keys_are_refused_as_anchors();
+    run_test_a_real_key_is_accepted_as_an_anchor();
+    run_test_a_genuine_package_verifies_under_its_own_key();
+    run_test_another_real_key_does_not_verify_the_package();
+    run_test_a_tampered_payload_is_rejected_by_the_signature();
+    run_test_removing_the_anchor_restores_refusal();
+    run_test_a_rejected_anchor_does_not_replace_the_one_in_force();
+
+    remove(EAPP_PATH);
+
+    tests_run = 8;
+    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/tests/test_pkg_trust_anchor.c
+++ b/tests/test_pkg_trust_anchor.c
@@ -22,9 +22,12 @@
  * CMakeLists -- which is why none of this was reachable by a test.
  */
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "eos_pkg.h"
 #include <eos/crypto.h>
@@ -125,7 +128,14 @@ static void write_eapp(const char *path,
     eos_sha256_update(&c, payload, payload_len);
     eos_sha256_final(&c, h.hash);
 
-    f = fopen(path, "wb");
+    /* Create with 0600 rather than fopen()'s 0666 & ~umask. These fixtures
+     * are the signed packages the verifier is about to trust, so a
+     * world-writable one lets anything on the box rewrite the payload
+     * between the write here and the read under test. */
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    ASSERT(fd >= 0);
+    f = fdopen(fd, "wb");
+    if (!f) close(fd);
     ASSERT(f != NULL);
     ASSERT(fwrite(&h, sizeof(h), 1, f) == 1);
     ASSERT(fwrite(payload, 1, payload_len, f) == payload_len);

--- a/tests/unit/test_cmake_test_registration.py
+++ b/tests/unit/test_cmake_test_registration.py
@@ -1,0 +1,116 @@
+"""Regression tests for the CTest registrations in tests/CMakeLists.txt.
+
+Every C suite in tests/ has to be named in tests/CMakeLists.txt to be compiled
+and run at all. Nothing else notices when one is left out: the suite stops
+building, ctest reports one fewer test, and the run still goes green.
+
+That is how test_mpu_validate.c stopped running. It landed together with the
+MPU fix it guards, and a later merge kept the file while dropping the
+add_executable() that built it -- so the six cases covering regions the MPU
+cannot program were compiled by nothing, and no run said so.
+
+These parse tests/CMakeLists.txt statically, so no cmake or compiler is needed.
+"""
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent.parent
+CMAKELISTS = TESTS_DIR / "CMakeLists.txt"
+
+ADD_EXECUTABLE_RE = re.compile(r"add_executable\(\s*(\w+)\s+([^)]*?)\)", re.S)
+ADD_TEST_RE = re.compile(r"add_test\(\s*NAME\s+(\w+)\s+COMMAND\s+(\w+)")
+
+#: Suites that are deliberately not built, and why. A name may only sit here
+#: with a reason that is about the suite itself -- "it is broken" is not one,
+#: because a broken suite is exactly what these tests exist to surface.
+NOT_BUILT = {
+    "test_net_integration.c":
+        "asserts stub semantics: test_accept_no_client() expects "
+        "eos_net_accept() to return EOS_SOCKET_INVALID, but the POSIX "
+        "implementation blocks, so the suite hangs rather than fails",
+    "test_firmware.c":
+        "links eos_systems, whose firmware.c calls eos_backend_find(); "
+        "backends/ is in no add_subdirectory() and its 12 sources no longer "
+        "compile against the current headers, so nothing can resolve it",
+    "test_profiles.c":
+        "cannot run a case: main() accepts only the literal strings "
+        '"products", "./products" and "../products", and products/ holds '
+        "headers, not the *.yaml the scan looks for -- it reports 0/0 and "
+        "exits 0, which is a pass that tested nothing",
+    "test_performance_benchmarks.c":
+        "asserts a wall-clock threshold (latency_ns < 100.0) measured by a "
+        "busy loop, which is a property of the runner rather than of the code",
+    "test_emulation_simulation.c":
+        "asserts a literal against itself -- mock_val == 0x55AA55AA one line "
+        "after mock_val is assigned that value -- and never reads the "
+        "register pointer it declares, so it cannot fail",
+}
+
+
+def _cmake_text():
+    return CMAKELISTS.read_text(encoding="utf-8")
+
+
+def _c_suites():
+    """Every C suite file in tests/, by file name."""
+    return sorted(p.name for p in TESTS_DIR.glob("test_*.c"))
+
+
+def _registered_sources():
+    """Source file names named by an add_executable() in tests/CMakeLists.txt."""
+    sources = set()
+    for _target, source_list in ADD_EXECUTABLE_RE.findall(_cmake_text()):
+        for source in source_list.split():
+            sources.add(Path(source).name)
+    return sources
+
+
+def test_every_c_suite_is_built_or_listed():
+    suites = _c_suites()
+    assert suites, "expected to find test_*.c suites in tests/"
+
+    registered = _registered_sources()
+    missing = [n for n in suites if n not in registered and n not in NOT_BUILT]
+
+    assert not missing, (
+        "these suites exist in tests/ but no add_executable() in "
+        "tests/CMakeLists.txt builds them, so they never run: "
+        f"{missing}. Register them, or add each to NOT_BUILT with the reason."
+    )
+
+
+def test_every_built_suite_is_registered_with_ctest():
+    text = _cmake_text()
+    targets = {t for t, _s in ADD_EXECUTABLE_RE.findall(text)}
+    commands = {c for _n, c in ADD_TEST_RE.findall(text)}
+
+    unregistered = sorted(targets - commands)
+    assert not unregistered, (
+        "these test executables are built but never added to ctest, so a "
+        f"failure in them cannot fail the build: {unregistered}"
+    )
+
+
+def test_not_built_list_has_no_stale_entries():
+    """A suite that has been registered must leave the exclusion list."""
+    registered = _registered_sources()
+    stale = sorted(n for n in NOT_BUILT if n in registered)
+    assert not stale, (
+        f"these are built now and should be dropped from NOT_BUILT: {stale}"
+    )
+
+
+def test_not_built_names_still_exist():
+    """An entry naming a file that is gone hides the next real omission."""
+    present = set(_c_suites())
+    gone = sorted(n for n in NOT_BUILT if n not in present)
+    assert not gone, f"NOT_BUILT names files that no longer exist: {gone}"
+
+
+def test_mpu_validate_suite_is_registered():
+    """Pin the specific suite whose registration a merge dropped."""
+    assert "test_mpu_validate.c" in _registered_sources(), (
+        "test_mpu_validate.c is not built by tests/CMakeLists.txt -- the MPU "
+        "region-programmability regression suite would silently stop running"
+    )


### PR DESCRIPTION
Closes the second half of #98 — the trust anchor, which @srpatcha called
"still the more important half" after #99 landed the verifier half.

## The state #99 left behind

#99 stopped `services/crypto` accepting low-order keys, which closed the half
where `eos_pkg` accepted every package. The anchor itself is untouched on
`master`:

```c
services/pkg/eos_pkg.c:94
static const uint8_t eos_pkg_public_key[32] = {0};
```

So `eos_pkg` went from accepting everything to rejecting everything. **Verified** —
a package whose payload is RFC 8032 §7.1 Test 2's message, carrying Test 2's real
signature, built against `master` unmodified:

```
== the package is genuinely signed ==
ed25519_verify with the correct key : ACCEPT
ed25519_verify with the zero anchor : reject

== what eos_pkg_verify() reports, with the anchor it ships ==
eos-pkg: signature verification failed
eos_pkg_verify rc = -1
```

The package is fine. The key was never provisioned. The message says the
opposite, so the one diagnostic an operator gets points away from the cause.

## Why nobody could have caught it

**Verified** — `services/pkg/eos_pkg.c` appears in no `CMakeLists.txt`:

```
$ grep -rn "services/pkg\|eos_pkg.c" --include=CMakeLists.txt .
(no matches)
```

Nothing compiled the file. `tests/test_package.c` tests `pkg/src/package.c` —
the build-recipe registry, a different module that happens to own the target
name `eos_pkg`. So the anchor was unreachable by any test, which is the reason
it survived four rounds of review.

It compiles clean as it stands (`-Wall -Wextra -Wpedantic`, 0 warnings); it was
simply never wired in. It is now the `eos_eapp` library.

## The fix

The key comes from the platform, in the shape this repository already uses:

| source | precedent |
|---|---|
| `eos_pkg_set_trust_anchor()` — where a keystore or provisioning step installs it | `eos_ota_set_authenticator()` (#75) |
| `EOS_PKG_TRUST_ANCHOR_HEX` — 64 hex characters from the build | — |
| neither → **refuse**, and say why | `EOS_ALLOW_STUB_CRYPTO` (#84), `EOS_ALLOW_UNSIGNED_OTA` (#75) |

`EOS_ALLOW_UNSIGNED_PKG` is the opt-in, for tests and bring-up.

An anchor is validated **when it is installed**, not once per package:

```
eos-pkg: refusing a trust anchor that is not a prime-order Ed25519 point;
         such a key cannot authenticate anything
```

That needed #99's checks to be reachable from outside `ed25519_verify()`, so
they are exported as `ed25519_public_key_is_usable()` rather than duplicated —
one implementation of the rule, one set of constants.

The three failures are reported apart because they call for different actions:
fix the provisioning, fix the build, or reject the package.

## Tests fail on the unfixed code

`tests/test_pkg_trust_anchor.c`, 8 tests. **Verified** they discriminate — built
against `master`'s `eos_pkg.c` with only the new symbols shimmed in so it links:

```
  test_no_anchor_refuses_a_genuine_package                 [PASS]
  test_low_order_keys_are_refused_as_anchors               [FAIL]
```

and with the anchor-validation half also shimmed in, so the run reaches the
verification path:

```
  test_no_anchor_refuses_a_genuine_package                 [PASS]
  test_low_order_keys_are_refused_as_anchors               [PASS]
  test_a_real_key_is_accepted_as_an_anchor                 [PASS]
  test_a_genuine_package_verifies_under_its_own_key        [FAIL]
```

Both halves of the change are load-bearing and independently proven.

Coverage: all eight low-order encodings refused as anchors — the all-zero value
this file shipped is only one of them; a real key accepted; a genuinely signed
package **accepted** under its own key, so a verifier that rejects everything
does not pass; a different real key rejected; a tampered payload rejected *with
the header hash recomputed over it*, so the SHA-256 check passes and only the
signature can reject it; and a rejected anchor leaving the one in force intact,
so a failed provisioning attempt cannot disarm a working installation.

## Verification

| item | result |
|---|---|
| `cmake -B build/host -DEOS_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release` | PASS |
| `test_pkg_trust_anchor` | PASS 8/8 |
| `eos_pkg.c` under `-Wall -Wextra -Wpedantic` | PASS, 0 warnings |
| ctest, this branch (macOS) | 34/35 |
| ctest, `master` same machine, same flags | 33/34 |

**Verified** — the single failure is `test_net`, identical on both sides and
pre-existing. It is macOS-only: `tests/test_net.c` calls `assert()` without
`#include <assert.h>`, which glibc admits transitively and clang does not. Not
touched here; worth its own one-line fix.

## Left open deliberately

- **Observed, not fixed:** `eos_pkg.c` runs `rm -rf "%s"` / `rmdir /s /q "%s"`
  through `system()` with an interpolated path (`eos_rmdir_recursive`). Now that
  the file is compiled, that is reachable code. It is a separate change and a
  separate argument; flagging it rather than folding it in.
- The `.eapp` payload is signed, the header is not — `entry`-style fields are
  outside the signature, the same shape as eBoot #40. Worth deciding on; not
  part of closing #98.
