### PR TITLE
fix(tests): restore POSIX network tests and kernel regression coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,26 @@
 # ---------------------------------------------------------------------------
 add_compile_options(-UNDEBUG)
 
+# ---------------------------------------------------------------------------
+# A check macro that is not declared is not a check.
+#
+# test_net.c called assert() with no <assert.h>: `assert` became an implicit
+# declaration, so the file did not compile on Clang >= 15 and did not link on
+# any toolchain (undefined reference to `assert`). ctest reported the whole
+# suite as Not Run.
+#
+# gcc-12, which the CI test job uses, only warns about an implicit
+# declaration, so nothing failed at the point the mistake was introduced.
+# Promoting it to an error here catches the next one at the same place.
+#
+# Test targets only, and only for the compiler families that spell the flag
+# this way -- MSVC uses /we4013 and nightly.yml builds these tests on
+# windows-latest. Mirrors the guard at CMakeLists.txt:14.
+# ---------------------------------------------------------------------------
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-Werror=implicit-function-declaration)
+endif()
+
 # EoS Unit Tests
 # --- test_board_configs: Board YAML schema shape ---
 add_executable(test_board_configs test_board_configs.c)

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -320,6 +320,7 @@ int main(void) {
     test_queue_full();
     test_task_stats();
     test_tick_overflow();
-    printf("=== ALL KERNEL TESTS PASSED (12/12) ===\n");
+    test_queue_send_waiter_overflow();
+    printf("=== ALL KERNEL TESTS PASSED (13/13) ===\n");
     return 0;
 }

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -9,9 +9,9 @@
 static int passed = 0;
 #define PASS(name) do { printf("[PASS] %s\n", name); passed++; } while(0)
 
-/* Not CHECK(): CI builds Release, and NDEBUG deletes CHECK() together with
+/* Not assert(): CI builds Release, and NDEBUG deletes assert() together with
  * the expression inside it. Half these checks wrap the call under test --
- * CHECK(eos_net_connect(...) == 0) stopped connecting at all, the echo
+ * assert(eos_net_connect(...) == 0) stopped connecting at all, the echo
  * thread blocked in accept() forever, and pthread_join() hung the suite. A
  * check macro must always evaluate its expression. */
 #define CHECK(cond) do { \
@@ -209,17 +209,17 @@ static void test_net_tcp_round_trip(void) {
         ts.tv_nsec = 5 * 1000 * 1000;
         nanosleep(&ts, NULL);
     }
-    assert(ready == 1);
+    CHECK(ready == 1);
     eos_socket_t c = eos_net_socket(EOS_NET_TCP);
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = g_test_port;
-    assert(eos_net_connect(c, &addr) == 0);
-    assert(eos_net_send(c, "ping", 4) == 4);
+    CHECK(eos_net_connect(c, &addr) == 0);
+    CHECK(eos_net_send(c, "ping", 4) == 4);
     char buf[32];
     memset(buf, 0, sizeof(buf));
-    assert(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
-    assert(strcmp(buf, "ping") == 0);
+    CHECK(eos_net_recv(c, buf, sizeof(buf) - 1, 2000) == 4);
+    CHECK(strcmp(buf, "ping") == 0);
     eos_net_close(c);
     pthread_join(t, NULL);
     eos_net_deinit();
@@ -229,13 +229,13 @@ static void test_net_tcp_round_trip(void) {
 static void test_net_resolve_localhost(void) {
     eos_net_init();
     uint32_t ip = 0;
-    assert(eos_net_resolve("localhost", &ip) == 0);
-    assert(ip == inet_addr("127.0.0.1"));
+    CHECK(eos_net_resolve("localhost", &ip) == 0);
+    CHECK(ip == inet_addr("127.0.0.1"));
     /* A name that cannot resolve must fail rather than reporting success and
      * leaving the caller with whatever was in the output already. */
     uint32_t before = ip;
-    assert(eos_net_resolve("no.such.host.invalid", &ip) == -1);
-    assert(ip == before);
+    CHECK(eos_net_resolve("no.such.host.invalid", &ip) == -1);
+    CHECK(ip == before);
     eos_net_deinit();
     PASS("net resolve localhost");
 }
@@ -246,7 +246,7 @@ static void test_net_connect_refused(void) {
     eos_net_addr_t addr;
     addr.ip = inet_addr("127.0.0.1");
     addr.port = 1;              /* nothing listens on port 1 */
-    assert(eos_net_connect(c, &addr) != 0);
+    CHECK(eos_net_connect(c, &addr) != 0);
     eos_net_close(c);
     eos_net_deinit();
     PASS("net connect to a closed port fails");


### PR DESCRIPTION
## Summary

Two test-only defects, each one where coverage that **already exists in the tree**
was not being executed. On current `master` the test suite does not build at all,
and one kernel regression test has been dead code since #97.

This PR changes **test code and test build configuration only**. No kernel,
network, driver, service, HAL or product source is touched, and no runtime
behaviour changes:

```
$ git diff upstream/master...HEAD --stat
 tests/CMakeLists.txt | 20 ++++++++++++++++++++
 tests/test_kernel.c  |  3 ++-
 tests/test_net.c     | 24 ++++++++++++------------
 3 files changed, 34 insertions(+), 13 deletions(-)
```

`git diff upstream/master...HEAD --stat -- kernel/ net/ core/ hal/ services/
drivers/ power/ include/ products/ CMakeLists.txt` is empty.

---

## 1. Understanding of the project I built before changing anything

Context I established first, so that the change I made would be the smallest one
that fits how this repository actually works.

**What EoS is.** A multi-platform embedded OS *framework* in pure C11 — not a
distro and not only an RTOS. One source tree provides a small RTOS kernel, a HAL
with host and bare-metal backends, a driver framework, and networking, power and
runtime-service layers, with 84 board descriptors and 48 product profiles
selected at configure time. Repository maturity is **Experimental** per
`STATUS.md`.

**Component layout**, each building its own static library:

| Library | Path | Contents |
|---|---|---|
| `eos_kernel` | `kernel/` | tasks, mutex with priority inheritance, semaphores, queues (`ipc.c`), multicore, heap |
| `eos_hal` | `hal/` | 33 peripherals; backend split `hal_linux.c` / `hal_rtos.c` |
| `eos_drivers` | `drivers/` | driver framework, devicetree parser |
| `eos_net` | `net/` | socket facade plus the POSIX backend `net_posix.c` |
| `eos_power` | `power/` | power management |
| core | `core/` | config parser, logging, dependency graph, cache, lockfile |
| services | `services/` | crypto, security, ota, sensor, motor, filesystem, gps, ui, init, compat |

**Execution paths.** Two distinct ones. On a host it is an ordinary `main()`
linking the static libraries — no boot. On bare metal, `kernel/src/arch/` startup
plus a board linker script runs `eos_kernel_init()` → `eos_task_create()` →
`eos_kernel_start()`, which enters the port layer. The kernel is **cooperative**:
blocking primitives end in `eos_port_yield()`. Host tests supply their own
`eos_port_*` mocks, which is what makes kernel tests runnable off-target — and it
is exactly the mechanism the restored kernel test depends on.

**Configuration model.** `-DEOS_PRODUCT=<name>` makes CMake define
`EOS_PRODUCT_<UPPER>`; `include/eos/eos_config.h` includes `products/<name>.h`,
which sets the `EOS_ENABLE_*` flags. Most service bodies and public types are
wrapped in `#if EOS_ENABLE_X`, so a header's types do not exist unless the right
product macro is defined. This is why `EOS_BUILD_TESTS=ON` requires
`-DEOS_PRODUCT=vbox_test`.

**Platform abstraction subtleties that matter here.** CMake, not the
preprocessor, selects the HAL backend and defines `EOS_HAL_BACKEND_HOST/_RTOS`.
Files needing POSIX headers are gated on `NOT CMAKE_CROSSCOMPILING`, deliberately
*not* on `EOS_PLATFORM`, because `EOS_PLATFORM` defaults to `linux` even for an
ARM cross build. That gate is what decides whether the code this PR touches is
compiled at all.

**Error conventions.** Three, by layer: `EOS_KERN_*` in the kernel, `EosResult`
in core, and `0`/`-1` in services and HAL.

**Test infrastructure.** 44 C suites driven by ctest, plus 10 pytest tests. The
suites express nearly every check as a bare `assert()`, so `tests/CMakeLists.txt`
carries `add_compile_options(-UNDEBUG)` (added by #104) to keep those assertions
alive in the Release build CI uses. Understanding that line was central to
choosing the fix in this PR.

---

## 2. Tests performed before fixing — the baseline

Measured on a clean checkout of `master` at `9861a3b`, in **both Debug and
Release**, with the project's documented commands and CI's own ctest flags.
Results were identical in both build types.

```
cmake -B build -DCMAKE_BUILD_TYPE=<Debug|Release> -DEOS_BUILD_TESTS=ON -DEOS_PRODUCT=vbox_test
cmake --build build --parallel
ctest --test-dir build --output-on-failure --no-tests=error --timeout 120 --parallel
python3 -m pytest tests/ -q
```

| Check | Baseline result |
|---|---|
| configure | PASS, exit 0 |
| build | **FAIL**, exit 2, **3 errors** |
| build warnings | 2 |
| ctest | **FAIL**, exit 8 — `97% tests passed, 1 tests failed out of 34`, `test_net (Not Run)` |
| `test_net` binary | never produced |
| `test_kernel` | 12/12 PASS, queue-overflow case **0 occurrences** |
| pytest | 10 passed |

The build failure, verbatim:

```
tests/test_net.c:212:5: error: call to undeclared function 'assert';
  ISO C99 and later do not support implicit function declarations
tests/test_net.c:232:5: error: ... (same)
tests/test_net.c:249:5: error: ... (same)
make[2]: *** [tests/CMakeFiles/test_net.dir/test_net.c.o] Error 1
```

Both baseline warnings turned out to be the two defects this PR fixes, sitting in
plain sight in every build log:

```
net/src/net.c:15:13:        warning: unused variable 'net_initialized'          [-Wunused-variable]   <- unrelated, out of scope
tests/test_kernel.c:159:13: warning: unused function 'test_queue_send_waiter_overflow' [-Wunused-function]
```

I also ran the clang static analyzer over all 54 library translation units to
make sure I was not missing a larger problem in the same area. It produced 50
warnings, of which 24 are the normal `deadcode.DeadStores` idiom in the Ed25519
ref10 code and the rest are `unused`. Nothing in `kernel/src/ipc.c` or
`net/src/net_posix.c`.

---

## 3. How I identified the bugs, and the code walkthrough

Neither defect came from guessing. Both were found by reading the two compiler
diagnostics the build was already emitting, then following them into git history.

### Bug 1 — `tests/test_net.c` calls `assert()` with no `<assert.h>`

Reading the file, the includes are `<stdio.h>`, `<stdlib.h>`, `<string.h>`, and
inside the `EOS_NET_POSIX` block `<arpa/inet.h>`, `<pthread.h>`, `<time.h>`. None
declares `assert`. So the ten `assert()` calls in that block compile as an
implicit call to a function that exists in no libc.

The file **already** contains the right mechanism, with a comment explaining why:

```c
#define CHECK(cond) do { \
    if (!(cond)) { \
        fprintf(stderr, "[FAIL] %s:%d: %s\n", __FILE__, __LINE__, #cond); \
        exit(1); \
    } \
} while (0)
```

So this was not a missing include — it was ten call sites that had fallen out of
the file's own convention.

I confirmed the defect two independent ways rather than trusting the one
diagnostic. Compile error on Clang ≥ 15, and — because `gcc-12`, which the CI
test job uses, only *warns* about an implicit declaration — I demoted the
diagnostic to reproduce gcc's behaviour and showed it fails at link instead:

```
$ cc -std=c11 -Wno-implicit-function-declaration -c tests/test_net.c -o t.o
$ nm -u t.o | grep -i assert
_assert
$ cc t.o libeos_net.a libeos_hal.a -lpthread
Undefined symbols for architecture arm64:
  "_assert", referenced from:
      _test_net_tcp_round_trip in t.o        (x5)
      _test_net_resolve_localhost in t.o     (x4)
      _test_net_connect_refused in t.o       (x1)
```
