### PR TITLE
fix(tests): add the missing assert.h include that broke master

### DIFF
--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #define EOS_ENABLE_NET 1
 #include "eos/eos_config.h"
 #include "eos/net.h"


### PR DESCRIPTION
`master` does not compile. **I broke it** — this is from #89, which I wrote.

```
tests/test_net.c:212:5: error: implicit declaration of function 'assert'
build errors: 4
```

`tests/test_net.c` calls `assert()` and never included `<assert.h>`. It compiled
on the development branch because `assert` arrived transitively through another
header there; that stopped being true once the file landed alongside a different
set of includes.

## Fix

One line. Verified on current `master`:

```
0 build errors
100% tests passed, 0 tests failed out of 34
```

## Why nobody caught it

```
$ gh api repos/embeddedos-org/eos/branches/master/protection
{"checks": null, "reviews": 1, "sigs": false}
```

No required status check. Nothing builds the merge result before it becomes
`master`, so a PR that is green on its own branch can land and break the tree —
which is #92, still open, and this is the third instance.

I have been filing that gap against other people's merges all week. It has now
caught me, in the most ordinary way possible: a header that was there on my
branch and not on the result. That is the argument for the gate, not against the
author — nobody reads every transitive include, and a machine does it for free.

Worth merging this and then marking the existing workflow required, while the
build is green. It is a settings change and it forecloses this specific failure
permanently.