### PR TITLE
test: register test_crypto_ed25519_loworder, which nothing built

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,13 @@ target_include_directories(test_hal_stm32f4 PRIVATE
 target_link_libraries(test_hal_stm32f4 PRIVATE eos_hal)
 add_test(NAME test_hal_stm32f4 COMMAND test_hal_stm32f4)
 
+# --- test_crypto_ed25519_loworder: prime-order subgroup enforcement ---
+# Landed with the fix it guards and was never registered, so the suite
+# that proves an all-zero package key is refused had never run.
+add_executable(test_crypto_ed25519_loworder test_crypto_ed25519_loworder.c)
+target_link_libraries(test_crypto_ed25519_loworder PRIVATE eos_crypto)
+add_test(NAME test_crypto_ed25519_loworder COMMAND test_crypto_ed25519_loworder)
+
 # --- test_security: Keystore, ACL ---
 add_executable(test_security test_security.c)
 target_link_libraries(test_security PRIVATE eos_security eos_crypto)


### PR DESCRIPTION
## master is red, and the guard is right

`CI — eos` on `769191a` fails in *Build & Test (Linux x86_64)*:

```
E  AssertionError: these suites exist in tests/ but no add_executable() in
   tests/CMakeLists.txt builds them, so they never run:
   ['test_crypto_ed25519_loworder.c']
FAILED tests/unit/test_cmake_test_registration.py::test_every_c_suite_is_built_or_listed
```

That is the guard from #114 catching exactly what it exists to catch, on its first real occurrence.

## What was not running

`tests/test_crypto_ed25519_loworder.c` — 164 lines — landed with the subgroup fix it guards and was never added to `tests/CMakeLists.txt`. Its own header states the bug it covers:

> eos_pkg.c shipped `static const uint8_t eos_pkg_public_key[32] = {0}` and the all-zero encoding is one of the eight, so package installation accepted every file handed to it.

So the five cases proving an all-zero package key is refused had **never once run**.

## Fix

It builds and passes as it stands, so it is registered rather than excluded — excluding it would need a reason, and "it works fine" is not one.

```
test_crypto_ed25519_loworder   5/5 passed
ctest                          39/39  (was 38)
pytest tests/                  15 passed
registration guard             5/5
```

Linked against `eos_crypto`, which is where `ed25519_verify` lives.
