### PR TITLE
fix(toolchain): master cannot link a Cortex-M4 executable — nosys.specs is passed twice

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,10 +90,6 @@ add_executable(test_crypto_rsa test_crypto_rsa.c)
 target_link_libraries(test_crypto_rsa PRIVATE eos_crypto)
 add_test(NAME test_crypto_rsa COMMAND test_crypto_rsa)
 
-# --- test_crypto_ed25519_loworder: reject keys outside the prime-order subgroup ---
-add_executable(test_crypto_ed25519_loworder test_crypto_ed25519_loworder.c)
-target_link_libraries(test_crypto_ed25519_loworder PRIVATE eos_crypto)
-add_test(NAME test_crypto_ed25519_loworder COMMAND test_crypto_ed25519_loworder)
 
 # --- test_crypto_sha512: SHA-512 against NIST vectors ---
 add_executable(test_crypto_sha512 test_crypto_sha512.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,11 @@ add_executable(test_crypto_rsa test_crypto_rsa.c)
 target_link_libraries(test_crypto_rsa PRIVATE eos_crypto)
 add_test(NAME test_crypto_rsa COMMAND test_crypto_rsa)
 
+# --- test_crypto_ed25519_loworder: reject keys outside the prime-order subgroup ---
+add_executable(test_crypto_ed25519_loworder test_crypto_ed25519_loworder.c)
+target_link_libraries(test_crypto_ed25519_loworder PRIVATE eos_crypto)
+add_test(NAME test_crypto_ed25519_loworder COMMAND test_crypto_ed25519_loworder)
+
 # --- test_crypto_sha512: SHA-512 against NIST vectors ---
 add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,7 +90,6 @@ add_executable(test_crypto_rsa test_crypto_rsa.c)
 target_link_libraries(test_crypto_rsa PRIVATE eos_crypto)
 add_test(NAME test_crypto_rsa COMMAND test_crypto_rsa)
 
-
 # --- test_crypto_sha512: SHA-512 against NIST vectors ---
 add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)

--- a/tests/unit/test_toolchain_specs.py
+++ b/tests/unit/test_toolchain_specs.py
@@ -29,31 +29,112 @@ REPO = Path(__file__).resolve().parents[2]
 TOOLCHAINS = REPO / "toolchains"
 
 # Variables CMake puts on the link line. C/CXX flags get there because CMake
-# links through the compiler driver.
+# links through the compiler driver. ASM is here because CMake picks a
+# target's linker language from its sources, so an executable built only from
+# .S files links with CMAKE_ASM_FLAGS -- a spec named there and in
+# CMAKE_EXE_LINKER_FLAGS_INIT is the same duplicate. No such target exists
+# today; a bare-metal tree acquires them.
 LINK_REACHING = (
     "CMAKE_C_FLAGS_INIT",
     "CMAKE_CXX_FLAGS_INIT",
+    "CMAKE_ASM_FLAGS_INIT",
     "CMAKE_EXE_LINKER_FLAGS_INIT",
 )
 
-SET_RE = re.compile(r'set\(\s*(\w+)\s+"([^"]*)"', re.S)
-SPECS_RE = re.compile(r'--?specs=(\S+)')
+# The .yaml descriptors are the second authority on these flags: the eos CLI
+# parses them into EosToolchain.cflags/ldflags (toolchains/src/toolchain.c),
+# a separate consumer from CMake. Nothing combines the two, so a .yaml naming
+# a spec in cflags is not a live duplicate -- but it is the same mistake in
+# the other description of the same toolchain, and nothing was checking it.
+YAML_LINK_REACHING = ("cflags", "ldflags")
+
+SPECS_RE = re.compile(r"--?specs=(\S+)")
+
+# set(VAR "value") and set(VAR value), the value possibly spanning lines.
+SET_RE = re.compile(r'set\(\s*(\w+)\s+("(?:[^"\\]|\\.)*"|[^)\n]+)\s*\)', re.S)
+# string(APPEND VAR " value") -- the ordinary way to add to these variables,
+# which the first version of this file could not see at all.
+APPEND_RE = re.compile(r'string\(\s*APPEND\s+(\w+)\s+("(?:[^"\\]|\\.)*"|[^)\n]+)\s*\)', re.S)
+REF_RE = re.compile(r"\$\{(\w+)\}")
+
+
+def _unquote(value):
+    value = value.strip()
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        return value[1:-1]
+    return value
+
+
+def _resolve(value, variables, depth=0):
+    """Expand ${VAR} against what the file has set so far.
+
+    arm-cortex-m4.cmake and arm-none-eabi-stm32f4.cmake both build their flag
+    strings from ${CPU_FLAGS}. Without this, putting -specs= into CPU_FLAGS
+    hides it from every check below while it still reaches two link-line
+    variables.
+    """
+    if depth > 8:
+        return value
+    def sub(match):
+        return _resolve(variables.get(match.group(1), ""), variables, depth + 1)
+    return REF_RE.sub(sub, value)
 
 
 def _specs_per_variable(text):
-    """{variable: [spec files]} for the variables that reach a link line."""
+    """{variable: [spec files]} for the variables that reach a link line.
+
+    The file is walked in order so that ${...} resolves against the values in
+    force at that point, which is what CMake does.
+    """
+    variables = {}
     found = {}
-    for var, value in SET_RE.findall(text):
+
+    events = [(m.start(), "set", m) for m in SET_RE.finditer(text)]
+    events += [(m.start(), "append", m) for m in APPEND_RE.finditer(text)]
+    events.sort()
+
+    for _pos, kind, match in events:
+        var = match.group(1)
+        value = _resolve(_unquote(match.group(2)), variables)
+        variables[var] = value if kind == "set" else (variables.get(var, "") + " " + value)
         if var in LINK_REACHING:
-            specs = SPECS_RE.findall(value)
+            specs = SPECS_RE.findall(variables[var])
             if specs:
                 found[var] = specs
+            else:
+                found.pop(var, None)
+    return found
+
+
+def _yaml_specs_per_key(text):
+    """{key: [spec files]} from a .yaml toolchain descriptor.
+
+    Read line-wise rather than with a YAML parser so the test has no
+    dependency the pytest job does not already install.
+    """
+    found = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key in YAML_LINK_REACHING:
+            specs = SPECS_RE.findall(value)
+            if specs:
+                found[key] = specs
     return found
 
 
 def _toolchain_files():
     files = sorted(TOOLCHAINS.glob("*.cmake"))
     assert files, f"no toolchain files found under {TOOLCHAINS}"
+    return files
+
+
+def _descriptor_files():
+    files = sorted(TOOLCHAINS.glob("*.yaml"))
+    assert files, f"no toolchain descriptors found under {TOOLCHAINS}"
     return files
 
 
@@ -88,10 +169,86 @@ def test_specs_are_declared_on_the_linker_flags_not_the_compiler_flags():
     offenders = []
     for path in _toolchain_files():
         per_var = _specs_per_variable(path.read_text())
-        for var in ("CMAKE_C_FLAGS_INIT", "CMAKE_CXX_FLAGS_INIT"):
+        for var in ("CMAKE_C_FLAGS_INIT", "CMAKE_CXX_FLAGS_INIT",
+                    "CMAKE_ASM_FLAGS_INIT"):
             for spec in per_var.get(var, []):
                 offenders.append(f"{path.name}: -specs={spec} is set in {var}")
     assert not offenders, (
         "declare spec files in CMAKE_EXE_LINKER_FLAGS_INIT:\n  "
         + "\n  ".join(offenders)
     )
+
+
+def test_descriptors_declare_specs_on_ldflags_only():
+    """The .yaml side already had this right; nothing was holding it there."""
+    offenders = []
+    for path in _descriptor_files():
+        per_key = _yaml_specs_per_key(path.read_text())
+        for spec in per_key.get("cflags", []):
+            offenders.append(f"{path.name}: -specs={spec} is in cflags")
+    assert not offenders, (
+        "a spec file is a link-time option; declare it in ldflags:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_a_spec_hidden_in_an_interpolated_variable_is_still_seen():
+    """The parser must follow ${...}, or the check is trivially bypassed.
+
+    Both ARM Cortex-M4 toolchains build their flags from ${CPU_FLAGS}. If a
+    spec were added there it would reach CMAKE_C_FLAGS_INIT and
+    CMAKE_EXE_LINKER_FLAGS_INIT while a literal-only scan saw neither.
+    """
+    text = (
+        'set(CPU_FLAGS "-mcpu=cortex-m4 -specs=nosys.specs")\n'
+        'set(CMAKE_C_FLAGS_INIT "${CPU_FLAGS} -ffunction-sections")\n'
+        'set(CMAKE_EXE_LINKER_FLAGS_INIT "${CPU_FLAGS} -Wl,--gc-sections")\n'
+    )
+    per_var = _specs_per_variable(text)
+    assert per_var.get("CMAKE_C_FLAGS_INIT") == ["nosys.specs"]
+    assert per_var.get("CMAKE_EXE_LINKER_FLAGS_INIT") == ["nosys.specs"]
+
+
+def test_a_spec_added_with_string_append_is_still_seen():
+    """string(APPEND ...) is the ordinary way to add to these variables."""
+    text = (
+        'set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--gc-sections")\n'
+        'string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " -specs=nosys.specs")\n'
+        'set(CMAKE_C_FLAGS_INIT "-specs=nosys.specs")\n'
+    )
+    per_var = _specs_per_variable(text)
+    assert per_var.get("CMAKE_EXE_LINKER_FLAGS_INIT") == ["nosys.specs"]
+    assert per_var.get("CMAKE_C_FLAGS_INIT") == ["nosys.specs"]
+
+
+def test_a_multi_line_set_is_still_seen():
+    """arm-none-eabi-stm32f4.cmake writes its linker flags across three lines.
+
+    An earlier revision of this parser required the closing paren on the same
+    line, so that file's specs were invisible to every check above while the
+    suite stayed green -- the failure mode this whole test exists to prevent,
+    one level up.
+    """
+    text = (
+        'set(CPU_FLAGS "-mcpu=cortex-m4")\n'
+        'set(CMAKE_EXE_LINKER_FLAGS_INIT\n'
+        '    "${CPU_FLAGS} -specs=nano.specs -specs=nosys.specs"\n'
+        ')\n'
+    )
+    per_var = _specs_per_variable(text)
+    assert per_var.get("CMAKE_EXE_LINKER_FLAGS_INIT") == [
+        "nano.specs", "nosys.specs"]
+
+
+def test_every_arm_toolchain_is_actually_parsed():
+    """A parser that silently sees nothing would pass every check above."""
+    seen = {
+        path.name: _specs_per_variable(path.read_text())
+        for path in _toolchain_files()
+    }
+    for name in ("arm-cortex-m4.cmake", "arm-none-eabi-r5.cmake",
+                 "arm-none-eabi-stm32f4.cmake"):
+        assert seen.get(name), (
+            f"{name} declares a spec file but the parser found none in it; "
+            f"the checks above are passing vacuously for this file"
+        )

--- a/tests/unit/test_toolchain_specs.py
+++ b/tests/unit/test_toolchain_specs.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+"""A -specs= file must reach the link line exactly once.
+
+`arm-none-eabi-gcc` fails outright when the same spec file is supplied twice:
+
+    fatal error: nosys.specs: attempt to rename spec 'link_gcc_c_sequence'
+                 to already defined spec 'nosys_link_gcc_c_sequence'
+
+CMake links through the compiler driver, so CMAKE_C_FLAGS_INIT reaches the
+link line too -- naming a spec there *and* in CMAKE_EXE_LINKER_FLAGS_INIT
+supplies it twice.
+
+Nothing in CI would notice. Every ARM toolchain here sets
+CMAKE_TRY_COMPILE_TARGET_TYPE to STATIC_LIBRARY and no cross build links an
+executable, so `Cross-compile ARM Cortex-M4` passed identically with the
+duplicate present and absent -- it passed on the unfixed commit. The defect
+was found by accident, when a PR briefly put cmd/eos into the cross build.
+This is the check that would have caught it, and it needs no ARM toolchain.
+
+Modelled on tests/unit/test_cmake_test_registration.py: parse the build files
+and fail on the class of mistake rather than on one instance of it.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+TOOLCHAINS = REPO / "toolchains"
+
+# Variables CMake puts on the link line. C/CXX flags get there because CMake
+# links through the compiler driver.
+LINK_REACHING = (
+    "CMAKE_C_FLAGS_INIT",
+    "CMAKE_CXX_FLAGS_INIT",
+    "CMAKE_EXE_LINKER_FLAGS_INIT",
+)
+
+SET_RE = re.compile(r'set\(\s*(\w+)\s+"([^"]*)"', re.S)
+SPECS_RE = re.compile(r'--?specs=(\S+)')
+
+
+def _specs_per_variable(text):
+    """{variable: [spec files]} for the variables that reach a link line."""
+    found = {}
+    for var, value in SET_RE.findall(text):
+        if var in LINK_REACHING:
+            specs = SPECS_RE.findall(value)
+            if specs:
+                found[var] = specs
+    return found
+
+
+def _toolchain_files():
+    files = sorted(TOOLCHAINS.glob("*.cmake"))
+    assert files, f"no toolchain files found under {TOOLCHAINS}"
+    return files
+
+
+def test_no_spec_file_reaches_the_link_line_twice():
+    offenders = []
+    for path in _toolchain_files():
+        per_var = _specs_per_variable(path.read_text())
+        seen = {}
+        for var, specs in per_var.items():
+            for spec in specs:
+                seen.setdefault(spec, []).append(var)
+        for spec, variables in seen.items():
+            if len(variables) > 1:
+                offenders.append(
+                    f"{path.name}: -specs={spec} is set in "
+                    f"{' and '.join(sorted(variables))}, so it reaches the "
+                    f"link line more than once"
+                )
+    assert not offenders, (
+        "arm-none-eabi-gcc rejects a duplicated spec file:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_specs_are_declared_on_the_linker_flags_not_the_compiler_flags():
+    """Where a toolchain names a spec at all, it names it on the link line.
+
+    Putting it in CMAKE_C_FLAGS_INIT happens to work today only because CMake
+    links through the driver. It is the arrangement that turns into a
+    duplicate the moment someone adds the linker entry that looks missing.
+    """
+    offenders = []
+    for path in _toolchain_files():
+        per_var = _specs_per_variable(path.read_text())
+        for var in ("CMAKE_C_FLAGS_INIT", "CMAKE_CXX_FLAGS_INIT"):
+            for spec in per_var.get(var, []):
+                offenders.append(f"{path.name}: -specs={spec} is set in {var}")
+    assert not offenders, (
+        "declare spec files in CMAKE_EXE_LINKER_FLAGS_INIT:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/toolchains/arm-cortex-m4.cmake
+++ b/toolchains/arm-cortex-m4.cmake
@@ -16,7 +16,20 @@ find_program(CMAKE_SIZE ${TOOLCHAIN_PREFIX}size)
 
 # CPU flags
 set(CPU_FLAGS "-mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16")
-set(CMAKE_C_FLAGS_INIT "${CPU_FLAGS} -ffunction-sections -fdata-sections -fno-common -specs=nosys.specs")
+# -specs=nosys.specs belongs on the link line only, and is set in
+# CMAKE_EXE_LINKER_FLAGS_INIT below. Having it here as well passed it to the
+# compiler driver twice whenever an executable was linked, and a specs file
+# may only be read once -- the second read tries to re-rename a spec it has
+# already renamed:
+#
+#   arm-none-eabi-gcc: fatal error: nosys.specs: attempt to rename spec
+#   'link_gcc_c_sequence' to already defined spec 'nosys_link_gcc_c_sequence'
+#
+# It stayed hidden because CMAKE_TRY_COMPILE_TARGET_TYPE is STATIC_LIBRARY and
+# nothing else in this build links an executable, so the duplicate never
+# reached a link line. arm-none-eabi-stm32f4.cmake already keeps the specs on
+# the linker flags alone; this matches it.
+set(CMAKE_C_FLAGS_INIT "${CPU_FLAGS} -ffunction-sections -fdata-sections -fno-common")
 set(CMAKE_ASM_FLAGS_INIT "${CPU_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--gc-sections -specs=nosys.specs -specs=nano.specs")
 

--- a/toolchains/arm-none-eabi-r5.cmake
+++ b/toolchains/arm-none-eabi-r5.cmake
@@ -18,9 +18,14 @@ set(CMAKE_SIZE         arm-none-eabi-size)
 set(CMAKE_AR           arm-none-eabi-ar)
 set(CMAKE_RANLIB       arm-none-eabi-ranlib)
 
-set(CMAKE_C_FLAGS_INIT   "-mcpu=cortex-r5 -mfloat-abi=hard -mfpu=vfpv3-d16 --specs=nosys.specs -ffunction-sections -fdata-sections -fno-common")
+# -specs= belongs on the link line only. It reached one here as well, via the
+# compiler driver, so this file was not broken -- but it was one added linker
+# -specs= away from the duplicate-spec failure arm-cortex-m4.cmake had, which
+# is the natural thing to write the first time an executable fails to link.
+# Moved so all three ARM bare-metal toolchains state it the same way.
+set(CMAKE_C_FLAGS_INIT   "-mcpu=cortex-r5 -mfloat-abi=hard -mfpu=vfpv3-d16 -ffunction-sections -fdata-sections -fno-common")
 set(CMAKE_CXX_FLAGS_INIT "${CMAKE_C_FLAGS_INIT}")
-set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--gc-sections -nostartfiles")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--gc-sections -nostartfiles -specs=nosys.specs")
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 


### PR DESCRIPTION
**`master` cannot link a Cortex-M4 executable.** `toolchains/arm-cortex-m4.cmake`
supplies `-specs=nosys.specs` twice — once on `CMAKE_C_FLAGS_INIT`, once on
`CMAKE_EXE_LINKER_FLAGS_INIT` — and CMake links through the compiler driver, so
both reach the link line:

```
arm-none-eabi-gcc: fatal error: .../nosys.specs: attempt to rename spec
'link_gcc_c_sequence' to already defined spec 'nosys_link_gcc_c_sequence'
```

This was originally written up as a cleanup. It is not. @srpatcha verified it
end to end on a host with `arm-none-eabi-gcc 14.2.1` and newlib: with `master`'s
toolchain file a three-line `add_executable()` project fails to build; with this
one it links. The earlier framing invited reviewers to deprioritise it, so it is
corrected here.

## Why CI never noticed, and still would not

Every ARM toolchain here sets `CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY`
and **no cross target links an executable**, so `Cross-compile ARM Cortex-M4`
passes identically with the duplicate present or absent — it passed on the
unfixed commit. The defect surfaced only by accident, when #118 briefly put
`cmd/eos` into the cross build; #118 has since gated that to host builds, which
removed the accident too.

So the signal is blind to this class, which is why the fix ships with a test.

## The change

```diff
-set(CMAKE_C_FLAGS_INIT "${CPU_FLAGS} -specs=nosys.specs -ffunction-sections …")
+set(CMAKE_C_FLAGS_INIT "${CPU_FLAGS} -ffunction-sections …")
```

Removing it from the compile line is provably a no-op: the whole of
`nosys.specs` is `%rename link_gcc_c_sequence` plus three `*link_*` entries —
no `*cc1`, no `*cpp` — so it cannot affect an object file.
`arm-none-eabi-stm32f4.cmake` already did it this way.

`arm-none-eabi-r5.cmake` moves the same flag from `CMAKE_C_FLAGS_INIT` to
`CMAKE_EXE_LINKER_FLAGS_INIT`. Behaviour-preserving — it reached the link line
once through the driver before and reaches it once directly now — and it is the
file that would reproduce this bug the moment anyone adds the linker entry that
looks missing.

**A trap for later edits:** `nosys.specs`'s `*nosys_libc` chooses `-lc` vs
`-lc_nano` by inspecting the command line for `specs=nano.specs`. The two specs
must therefore stay on the same line; neither can be moved to compile flags
"for symmetry".

## The test

`tests/unit/test_toolchain_specs.py` parses every `toolchains/*.cmake` and
`*.yaml` and fails if a spec file reaches the link line more than once, or is
declared on compile flags at all. Modelled on
`test_cmake_test_registration.py`: fail on the class, not the instance. Needs no
ARM toolchain and runs in the existing pytest job.

It walks each file in order with a variable table, so a spec reaches the checks
however it is written — `set()` quoted or not, `string(APPEND …)`, or hidden
inside an interpolated `${CPU_FLAGS}`, which is how both Cortex-M4 files build
their flag strings.

Parser output on the current tree:

```
arm-cortex-m4.cmake         CMAKE_EXE_LINKER_FLAGS_INIT: [nosys.specs, nano.specs]
arm-none-eabi-r5.cmake      CMAKE_EXE_LINKER_FLAGS_INIT: [nosys.specs]
arm-none-eabi-stm32f4.cmake CMAKE_EXE_LINKER_FLAGS_INIT: [nano.specs, nosys.specs]
```

Mutations caught: the original duplicate re-introduced; a spec hidden in
`CPU_FLAGS`; and a parser that sees nothing at all
(`test_every_arm_toolchain_is_actually_parsed`, added after my first regex
silently failed to read `stm32f4`'s three-line `set()` and every check passed
vacuously for that file).

## Known limit

The strongest test would configure a throwaway `add_executable()` and inspect
the generated link line — it would have caught this directly rather than by
pattern. It is not here because it needs `arm-none-eabi-gcc` on the runner,
which the pytest job does not install, so it would skip on CI and run only where
someone already has the toolchain. A test that is green because it did not run
is worse than the pattern check. Worth a follow-up that installs the toolchain.

## CI

Two reds, both inherited, neither from this branch:

- `Cross-compile ARM64 kernel` builds `embeddedos-org/eBoot@master`, which does
  not compile (`eos_image.h`: `'eos_image_header_t' has no member named
  'reserved'`). eBoot#94 is the repair.
- `Run Python tests` fails on the `test_crypto_ed25519_loworder` registration
  that #93 removed. **#127 is the fix** — #125 is closed and #128 was closed as
  a duplicate.

An earlier revision of this branch carried #127's registration hunk, which made
that check green here and is why the 2026-09-02 comments read as they do. It has
been removed: folding a master repair into a toolchain PR to get a green tick is
how a red master becomes everyone's problem to route around.

## Verification

| item | result |
|---|---|
| `pytest tests/unit/test_toolchain_specs.py` | PASS — 7 passed |
| `ctest` | PASS — 38/38 |
| link an executable with `master`'s toolchain | **FAILS** (verified by @srpatcha, gcc 14.2.1 + newlib) |
| link the same with this branch's | PASS |
