### PR TITLE
ci: finish the EoSim fix — a tag that exists, and no wheel anywhere

### DIFF
--- a/.github/actions/install-eosim/action.yml
+++ b/.github/actions/install-eosim/action.yml
@@ -1,0 +1,61 @@
+name: Install EoSim
+description: >
+  Clone EoSim at a pinned commit, install it, stage its platform data, and
+  assert the installed dist version. One home for a recipe that was previously
+  copy-pasted at seven sites across two workflows -- each of its three past
+  fixes (-e dropped, runner.temp, shell: bash) had to be applied per site,
+  which is how the sites drifted. This is also the one place to delete the
+  platforms/ workaround from when EoSim fixes its packaging.
+
+inputs:
+  commit:
+    description: Full SHA of the EoSim commit to install.
+    required: true
+  expected-dist:
+    description: >
+      The version that commit's pyproject.toml declares to pip. Asserted via
+      importlib.metadata -- the CLI's own --version is a hardcoded literal in
+      EoSim (eosim/cli/main.py) and prints 2.0.0 from every tag, so it cannot
+      detect a wrong install. Dist metadata is the only version the pin
+      controls.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Clone and install EoSim at the pinned commit
+      shell: bash
+      run: |
+        set -euo pipefail
+        git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${RUNNER_TEMP}/EoSim"
+        git -C "${RUNNER_TEMP}/EoSim" checkout --detach "${{ inputs.commit }}"
+        pip install "${RUNNER_TEMP}/EoSim"
+
+    - name: Stage platform data
+      shell: bash
+      run: |
+        set -euo pipefail
+        # platforms/ is data, not package data: eosim resolves PLATFORMS_DIR
+        # to <site-packages>/platforms while the package ships only
+        # eosim/platforms/__init__.py. Without this copy every `eosim run`
+        # fails with FileNotFoundError -- found on the first execution these
+        # workflows ever had.
+        #
+        # sysconfig, not dirname(dirname(eosim.__file__)): purelib needs no
+        # import and cannot be shadowed by a same-named directory on
+        # sys.path. Matches eBoot's copy of this workaround.
+        SITE_PACKAGES=$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+        cp -r "${RUNNER_TEMP}/EoSim/platforms" "$SITE_PACKAGES/"
+
+    - name: Assert the installed dist version
+      shell: bash
+      run: |
+        set -euo pipefail
+        python - <<'PYEOF'
+        import importlib.metadata as m
+        import sys
+        got = m.version("eosim")
+        want = "${{ inputs.expected-dist }}"
+        print(f"eosim dist version: {got}")
+        sys.exit(0 if got == want else f"expected {want}, got {got}")
+        PYEOF

--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -9,6 +9,15 @@ on:
 
 env:
   EOS_VERSION: "0.6.0"
+  # The kernel job compiles eBoot and checks out ebuild. Those used to float on
+  # `ref: master`, so the moment either repo's master stopped compiling, every
+  # open eos PR went red for a reason no eos change caused and no eos change
+  # could fix (2026-09-03: eBoot master's eos_image.h asserts a member that no
+  # longer exists, and its ed25519_verify.c has a redefined helper -- eBoot #94
+  # repairs it). A dependency is pinned and bumped deliberately; when eBoot #94
+  # lands, bump EBOOT_COMMIT to that merge and CI will say whether it holds.
+  EBOOT_COMMIT: "a172a6d6e1e66877413ed546401a65ee4f4f90db"
+  EBUILD_COMMIT: "e5d8052f3e2cfdcb1c91bab8300087aa07e02679"
   CROSS_COMPILE: "aarch64-linux-gnu-"
   QEMU_MACHINE: "virt"
   QEMU_CPU: "cortex-a57"
@@ -29,14 +38,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/eBoot
-          ref: master
+          ref: ${{ env.EBOOT_COMMIT }}
           path: eBoot
 
       - name: Checkout ebuild
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/ebuild
-          ref: master
+          ref: ${{ env.EBUILD_COMMIT }}
           path: ebuild
 
       # embeddedos-org/eFab does not exist -- the checkout 404s and takes this
@@ -276,7 +285,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/ebuild
-          ref: master
+          ref: ${{ env.EBUILD_COMMIT }}
 
       # Same missing repository as in build-kernel.
       # - name: Checkout eFab

--- a/.github/workflows/eosim-sanity.yml
+++ b/.github/workflows/eosim-sanity.yml
@@ -111,6 +111,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install EoSim from source
+        # shell: bash -- this job also runs on windows-latest, where the
+        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
+        # comment are all invalid there, which is how the first real run
+        # of this workflow failed on all three Windows legs while ubuntu
+        # and macOS passed.
+        shell: bash
         run: |
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
@@ -125,6 +131,12 @@ jobs:
           SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
           cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
       - name: Verify installation
+        # shell: bash -- this job also runs on windows-latest, where the
+        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
+        # comment are all invalid there, which is how the first real run
+        # of this workflow failed on all three Windows legs while ubuntu
+        # and macOS passed.
+        shell: bash
         run: |
           eosim --version
           # `eosim --version` is a hardcoded literal in EoSim
@@ -140,6 +152,12 @@ jobs:
           "
           eosim list
       - name: Validate all platform configs
+        # shell: bash -- this job also runs on windows-latest, where the
+        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
+        # comment are all invalid there, which is how the first real run
+        # of this workflow failed on all three Windows legs while ubuntu
+        # and macOS passed.
+        shell: bash
         run: eosim list && eosim doctor
 
   nested-simulation:
@@ -163,6 +181,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install EoSim from source
+        # shell: bash -- this job also runs on windows-latest, where the
+        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
+        # comment are all invalid there, which is how the first real run
+        # of this workflow failed on all three Windows legs while ubuntu
+        # and macOS passed.
+        shell: bash
         run: |
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
@@ -201,6 +225,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install EoSim from source
+        # shell: bash -- this job also runs on windows-latest, where the
+        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
+        # comment are all invalid there, which is how the first real run
+        # of this workflow failed on all three Windows legs while ubuntu
+        # and macOS passed.
+        shell: bash
         run: |
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
@@ -230,6 +260,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Test EoSim on Windows
+        # shell: bash -- this job also runs on windows-latest, where the
+        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
+        # comment are all invalid there, which is how the first real run
+        # of this workflow failed on all three Windows legs while ubuntu
+        # and macOS passed.
+        shell: bash
         run: |
           # No EoSim release ships a wheel, so this URL 404s. The other jobs
           # in this workflow already install from a clone; these two were

--- a/.github/workflows/eosim-sanity.yml
+++ b/.github/workflows/eosim-sanity.yml
@@ -113,7 +113,11 @@ jobs:
           python-version: "3.12"
       - name: Test EoSim on Windows
         run: |
-          pip install "eosim @ https://github.com/embeddedos-org/EoSim/releases/download/v${{ env.EOSIM_VERSION }}/eosim-${{ env.EOSIM_VERSION }}-py3-none-any.whl"
+          # No EoSim release ships a wheel, so this URL 404s. The other jobs
+          # in this workflow already install from a clone; these two were
+          # missed.
+          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
+          pip install -e /tmp/EoSim
           eosim --version
           eosim list && eosim doctor
           eosim list
@@ -129,7 +133,11 @@ jobs:
           python-version: "3.12"
       - name: Test EoSim on macOS
         run: |
-          pip install "eosim @ https://github.com/embeddedos-org/EoSim/releases/download/v${{ env.EOSIM_VERSION }}/eosim-${{ env.EOSIM_VERSION }}-py3-none-any.whl"
+          # No EoSim release ships a wheel, so this URL 404s. The other jobs
+          # in this workflow already install from a clone; these two were
+          # missed.
+          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
+          pip install -e /tmp/EoSim
           eosim --version
           eosim list && eosim doctor
           eosim list

--- a/.github/workflows/eosim-sanity.yml
+++ b/.github/workflows/eosim-sanity.yml
@@ -71,7 +71,12 @@ jobs:
   # failing the day EoSim publishes something, which is when it should be
   # deleted and the installs pointed at the artifact.
   published-artifact-watch:
-    name: EoSim publishes no installable artifact (tracking)
+    name: EoSim artifact publication (informational)
+    # Neither branch of this job can fail -- it is a notice, not a check --
+    # so it sits outside sanity-gate's needs and runs only on the schedule
+    # and on manual dispatch: a permanently-green status named for a
+    # deficiency on every pull request helps nobody.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Look for a wheel or sdist on any release
@@ -110,26 +115,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install EoSim from source
-        # shell: bash -- this job also runs on windows-latest, where the
-        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
-        # comment are all invalid there, which is how the first real run
-        # of this workflow failed on all three Windows legs while ubuntu
-        # and macOS passed.
-        shell: bash
-        run: |
-          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
-          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
-          pip install "${{ runner.temp }}/EoSim"
-          # platforms/ is data, not package data: eosim/cli/main.py sets
-          # PLATFORMS_DIR to <site-packages>/platforms, while the package
-          # ships only eosim/platforms/__init__.py. Without this copy every
-          # `eosim run` fails with
-          #   FileNotFoundError: .../site-packages/platforms
-          # which is what the first real run of this workflow showed -- the
-          # missing v0.1.0 tag was the first blocker, not the only one.
-          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
-          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
+      - name: Install EoSim (pinned)
+        uses: ./.github/actions/install-eosim
+        with:
+          commit: ${{ env.EOSIM_COMMIT }}
+          expected-dist: ${{ env.EOSIM_EXPECTED_DIST }}
       - name: Verify installation
         # shell: bash -- this job also runs on windows-latest, where the
         # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
@@ -139,17 +129,7 @@ jobs:
         shell: bash
         run: |
           eosim --version
-          # `eosim --version` is a hardcoded literal in EoSim
-          # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it
-          # cannot tell a right install from a wrong one. Assert what pip
-          # actually resolved instead -- dist metadata is the only version the
-          # commit pin controls.
-          python -c "
-          import importlib.metadata as m, os, sys
-          got = m.version('eosim'); want = os.environ['EOSIM_EXPECTED_DIST']
-          print(f'eosim dist version: {got}')
-          sys.exit(0 if got == want else f'expected {want}, got {got}')
-          "
+          # dist-version assert lives in the install-eosim composite action
           eosim list
       - name: Validate all platform configs
         # shell: bash -- this job also runs on windows-latest, where the
@@ -180,26 +160,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install EoSim from source
-        # shell: bash -- this job also runs on windows-latest, where the
-        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
-        # comment are all invalid there, which is how the first real run
-        # of this workflow failed on all three Windows legs while ubuntu
-        # and macOS passed.
-        shell: bash
-        run: |
-          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
-          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
-          pip install "${{ runner.temp }}/EoSim"
-          # platforms/ is data, not package data: eosim/cli/main.py sets
-          # PLATFORMS_DIR to <site-packages>/platforms, while the package
-          # ships only eosim/platforms/__init__.py. Without this copy every
-          # `eosim run` fails with
-          #   FileNotFoundError: .../site-packages/platforms
-          # which is what the first real run of this workflow showed -- the
-          # missing v0.1.0 tag was the first blocker, not the only one.
-          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
-          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
+      - name: Install EoSim (pinned)
+        uses: ./.github/actions/install-eosim
+        with:
+          commit: ${{ env.EOSIM_COMMIT }}
+          expected-dist: ${{ env.EOSIM_EXPECTED_DIST }}
       - name: Simulate ${{ matrix.platform }}
         run: |
           eosim run ${{ matrix.platform }} --headless --timeout 10
@@ -224,26 +189,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install EoSim from source
-        # shell: bash -- this job also runs on windows-latest, where the
-        # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
-        # comment are all invalid there, which is how the first real run
-        # of this workflow failed on all three Windows legs while ubuntu
-        # and macOS passed.
-        shell: bash
-        run: |
-          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
-          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
-          pip install "${{ runner.temp }}/EoSim"
-          # platforms/ is data, not package data: eosim/cli/main.py sets
-          # PLATFORMS_DIR to <site-packages>/platforms, while the package
-          # ships only eosim/platforms/__init__.py. Without this copy every
-          # `eosim run` fails with
-          #   FileNotFoundError: .../site-packages/platforms
-          # which is what the first real run of this workflow showed -- the
-          # missing v0.1.0 tag was the first blocker, not the only one.
-          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
-          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
+      - name: Install EoSim (pinned)
+        uses: ./.github/actions/install-eosim
+        with:
+          commit: ${{ env.EOSIM_COMMIT }}
+          expected-dist: ${{ env.EOSIM_EXPECTED_DIST }}
       - name: Boot guest and test EoSim inside
         run: |
           echo "=== Nested Guest: ${{ matrix.guest }} ==="
@@ -259,6 +209,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install EoSim (pinned)
+        uses: ./.github/actions/install-eosim
+        with:
+          commit: ${{ env.EOSIM_COMMIT }}
+          expected-dist: ${{ env.EOSIM_EXPECTED_DIST }}
       - name: Test EoSim on Windows
         # shell: bash -- this job also runs on windows-latest, where the
         # runner default is pwsh. `VAR=$(...)`, `cp -r` and a leading `#`
@@ -270,9 +225,6 @@ jobs:
           # No EoSim release ships a wheel, so this URL 404s. The other jobs
           # in this workflow already install from a clone; these two were
           # missed.
-          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
-          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
-          pip install "${{ runner.temp }}/EoSim"
           # platforms/ is data, not package data: eosim/cli/main.py sets
           # PLATFORMS_DIR to <site-packages>/platforms, while the package
           # ships only eosim/platforms/__init__.py. Without this copy every
@@ -280,20 +232,8 @@ jobs:
           #   FileNotFoundError: .../site-packages/platforms
           # which is what the first real run of this workflow showed -- the
           # missing v0.1.0 tag was the first blocker, not the only one.
-          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
-          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
           eosim --version
-          # `eosim --version` is a hardcoded literal in EoSim
-          # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it
-          # cannot tell a right install from a wrong one. Assert what pip
-          # actually resolved instead -- dist metadata is the only version the
-          # commit pin controls.
-          python -c "
-          import importlib.metadata as m, os, sys
-          got = m.version('eosim'); want = os.environ['EOSIM_EXPECTED_DIST']
-          print(f'eosim dist version: {got}')
-          sys.exit(0 if got == want else f'expected {want}, got {got}')
-          "
+          # dist-version assert lives in the install-eosim composite action
           eosim list && eosim doctor
           eosim list
 
@@ -306,14 +246,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install EoSim (pinned)
+        uses: ./.github/actions/install-eosim
+        with:
+          commit: ${{ env.EOSIM_COMMIT }}
+          expected-dist: ${{ env.EOSIM_EXPECTED_DIST }}
       - name: Test EoSim on macOS
         run: |
           # No EoSim release ships a wheel, so this URL 404s. The other jobs
           # in this workflow already install from a clone; these two were
           # missed.
-          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
-          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
-          pip install "${{ runner.temp }}/EoSim"
           # platforms/ is data, not package data: eosim/cli/main.py sets
           # PLATFORMS_DIR to <site-packages>/platforms, while the package
           # ships only eosim/platforms/__init__.py. Without this copy every
@@ -321,27 +263,15 @@ jobs:
           #   FileNotFoundError: .../site-packages/platforms
           # which is what the first real run of this workflow showed -- the
           # missing v0.1.0 tag was the first blocker, not the only one.
-          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
-          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
           eosim --version
-          # `eosim --version` is a hardcoded literal in EoSim
-          # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it
-          # cannot tell a right install from a wrong one. Assert what pip
-          # actually resolved instead -- dist metadata is the only version the
-          # commit pin controls.
-          python -c "
-          import importlib.metadata as m, os, sys
-          got = m.version('eosim'); want = os.environ['EOSIM_EXPECTED_DIST']
-          print(f'eosim dist version: {got}')
-          sys.exit(0 if got == want else f'expected {want}, got {got}')
-          "
+          # dist-version assert lives in the install-eosim composite action
           eosim list && eosim doctor
           eosim list
 
   sanity-gate:
     name: EoSim Sanity Gate
     if: always()
-    needs: [published-artifact-watch, install-validate, nested-simulation,
+    needs: [install-validate, nested-simulation,
             nested-guest-install, windows-sanity, macos-sanity]
     runs-on: ubuntu-latest
     steps:
@@ -356,6 +286,17 @@ jobs:
         env:
           RESULTS: ${{ toJSON(needs) }}
         run: |
+          set -euo pipefail
+          # Refuse to conclude anything from nothing. An empty or null
+          # RESULTS previously printed "all succeeded" and exited 0 here,
+          # where eos#121's extracted ci-gate-check.sh refuses -- measured
+          # side by side. Once #121's script is on master this body should
+          # become a call to it; until then the guards are replicated inline
+          # so the two cannot disagree on the inputs that matter.
+          if [ -z "${RESULTS:-}" ] || [ "$RESULTS" = "null" ]; then
+            echo "::error::gate received no results to check"
+            exit 1
+          fi
           printf '%s\n' "$RESULTS"
           bad=$(printf '%s' "$RESULTS" | jq -r '
             to_entries[]

--- a/.github/workflows/eosim-sanity.yml
+++ b/.github/workflows/eosim-sanity.yml
@@ -4,7 +4,14 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
-
+  # A change to this file tests itself. Without this the workflow was
+  # schedule- and dispatch-only, so a pull request editing it produced no run
+  # of it at all -- every green check on such a PR was some other workflow,
+  # and the only evidence for the change was whatever the author did locally.
+  pull_request:
+    paths:
+      - '.github/workflows/eosim-sanity.yml'
+      - '.github/workflows/simulation-test.yml'
 permissions:
   contents: read
 
@@ -13,13 +20,83 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # v0.1.0 has never existed. embeddedos-org/EoSim tags v1.0.0 through
-  # v3.0.1, so `git clone --branch v0.1.0` fails with "Remote branch
+  # Pinned by commit, not by tag name.
+  #
+  # v0.1.0 has never existed -- embeddedos-org/EoSim tags v1.0.0 through
+  # v3.0.1 -- so `git clone --branch v0.1.0` failed with "Remote branch
   # v0.1.0 not found in upstream origin" and this workflow has never had a
-  # green run. v1.5.0 is the release marked Latest and installs from source.
-  EOSIM_VERSION: "1.5.0"
-
+  # green run.
+  #
+  # The obvious replacement, v1.5.0, is a label rather than a version. Checked
+  # against the remote on 2026-09-03:
+  #
+  #   tag      commit    committed     commit subject          pyproject  __init__
+  #   v1.5.0   7dec3460  2026-05-27    "production-ready v1.4.0"   3.0.1     3.0.1
+  #   v3.0.1   b297ec26  2026-05-16    "v3.0.1 — unified ..."      3.0.1     2.0.0
+  #
+  # v1.5.0 is the release GitHub marks Latest, is the newest tag by commit
+  # date, tags a commit whose own message claims v1.4.0, and installs a dist
+  # declaring 3.0.1. The tag namespace is neither ordered nor descriptive of
+  # its contents, so `EOSIM_VERSION: "1.5.0"` would tell a reader that eos is
+  # simulated against EoSim 1.5.0 -- which is not true, and which no amount of
+  # re-reading this file would reveal.
+  #
+  # A SHA says exactly what is installed and cannot be moved under us. Switch
+  # back to a tag once EoSim's tags mean something; see the EoSim issue linked
+  # from the PR.
+  EOSIM_COMMIT: "7dec3460cba76083b6645eb4a867e39aa2af97df"   # v1.5.0 as of 2026-09-03
+  # The version that commit's pyproject.toml declares to pip. Asserted after
+  # install, because the CLI's own version flag cannot detect a wrong install:
+  # EoSim hardcodes it (eosim/cli/main.py:49,
+  # @click.version_option(version="2.0.0")), so it prints 2.0.0 from every
+  # tag. Dist metadata is the only version the commit pin actually controls.
+  EOSIM_EXPECTED_DIST: "3.0.1"
 jobs:
+  # Every install in this workflow is now `git clone` + `pip install <path>`,
+  # because no EoSim release ships a Python artifact. Verified against the
+  # remote on 2026-09-03: 13 releases, assets are promo .mp4 files, a
+  # manifest.json and EoSim-guide.pdf -- no wheel, no sdist at any tag -- and
+  # https://pypi.org/pypi/eosim/json returns 404.
+  #
+  # That means this workflow no longer exercises the path a developer outside
+  # the org would take. Master design §17 makes EoSim an adoption primitive
+  # ("Discover -> Install -> ebuild run --sim", "in minutes, not hours") and
+  # §10 says repositories should not be the dependency API; today a git URL is
+  # the only route that exists.
+  #
+  # Converting to a clone is the right immediate move -- a permanent 404 is
+  # not a useful red -- but it would also make the gap green and invisible.
+  # This job keeps it visible: it does not fail the workflow, and it says out
+  # loud, on every run, that the packaging debt is still open. It starts
+  # failing the day EoSim publishes something, which is when it should be
+  # deleted and the installs pointed at the artifact.
+  published-artifact-watch:
+    name: EoSim publishes no installable artifact (tracking)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Look for a wheel or sdist on any release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          assets=$(gh api repos/embeddedos-org/EoSim/releases --paginate \
+                     --jq '[.[].assets[].name] | map(select(test("\\.(whl|tar\\.gz)$"))) | join(" ")')
+          pypi=$(curl -s -o /dev/null -w '%{http_code}' https://pypi.org/pypi/eosim/json)
+
+          echo "release assets matching *.whl / *.tar.gz: ${assets:-<none>}"
+          echo "pypi.org/pypi/eosim/json: HTTP $pypi"
+
+          if [ -n "$assets" ] || [ "$pypi" = "200" ]; then
+            echo "::notice::EoSim now publishes an installable artifact."
+            echo "The clone-and-install steps in this workflow should be"
+            echo "switched to it, and this job deleted."
+          else
+            echo "::warning::EoSim publishes no wheel or sdist, and is not on"
+            echo "PyPI. Every job here installs from a git clone, so the"
+            echo "published-artifact path is untested across the org. Tracked"
+            echo "against EoSim; see the note in this workflow's env block."
+          fi
+
   install-validate:
     name: Install & Validate (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
@@ -35,11 +112,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install EoSim from source
         run: |
-          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
-          pip install -e /tmp/EoSim
+          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
+          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
+          pip install "${{ runner.temp }}/EoSim"
       - name: Verify installation
         run: |
           eosim --version
+          # `eosim --version` is a hardcoded literal in EoSim
+          # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it
+          # cannot tell a right install from a wrong one. Assert what pip
+          # actually resolved instead -- dist metadata is the only version the
+          # commit pin controls.
+          python -c "
+          import importlib.metadata as m, os, sys
+          got = m.version('eosim'); want = os.environ['EOSIM_EXPECTED_DIST']
+          print(f'eosim dist version: {got}')
+          sys.exit(0 if got == want else f'expected {want}, got {got}')
+          "
           eosim list
       - name: Validate all platform configs
         run: eosim list && eosim doctor
@@ -66,8 +155,9 @@ jobs:
           python-version: "3.12"
       - name: Install EoSim from source
         run: |
-          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
-          pip install -e /tmp/EoSim
+          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
+          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
+          pip install "${{ runner.temp }}/EoSim"
       - name: Simulate ${{ matrix.platform }}
         run: |
           eosim run ${{ matrix.platform }} --headless --timeout 10
@@ -94,8 +184,9 @@ jobs:
           python-version: "3.12"
       - name: Install EoSim from source
         run: |
-          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
-          pip install -e /tmp/EoSim
+          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
+          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
+          pip install "${{ runner.temp }}/EoSim"
       - name: Boot guest and test EoSim inside
         run: |
           echo "=== Nested Guest: ${{ matrix.guest }} ==="
@@ -116,9 +207,21 @@ jobs:
           # No EoSim release ships a wheel, so this URL 404s. The other jobs
           # in this workflow already install from a clone; these two were
           # missed.
-          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
-          pip install -e /tmp/EoSim
+          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
+          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
+          pip install "${{ runner.temp }}/EoSim"
           eosim --version
+          # `eosim --version` is a hardcoded literal in EoSim
+          # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it
+          # cannot tell a right install from a wrong one. Assert what pip
+          # actually resolved instead -- dist metadata is the only version the
+          # commit pin controls.
+          python -c "
+          import importlib.metadata as m, os, sys
+          got = m.version('eosim'); want = os.environ['EOSIM_EXPECTED_DIST']
+          print(f'eosim dist version: {got}')
+          sys.exit(0 if got == want else f'expected {want}, got {got}')
+          "
           eosim list && eosim doctor
           eosim list
 
@@ -136,30 +239,50 @@ jobs:
           # No EoSim release ships a wheel, so this URL 404s. The other jobs
           # in this workflow already install from a clone; these two were
           # missed.
-          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
-          pip install -e /tmp/EoSim
+          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
+          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
+          pip install "${{ runner.temp }}/EoSim"
           eosim --version
+          # `eosim --version` is a hardcoded literal in EoSim
+          # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it
+          # cannot tell a right install from a wrong one. Assert what pip
+          # actually resolved instead -- dist metadata is the only version the
+          # commit pin controls.
+          python -c "
+          import importlib.metadata as m, os, sys
+          got = m.version('eosim'); want = os.environ['EOSIM_EXPECTED_DIST']
+          print(f'eosim dist version: {got}')
+          sys.exit(0 if got == want else f'expected {want}, got {got}')
+          "
           eosim list && eosim doctor
           eosim list
 
   sanity-gate:
     name: EoSim Sanity Gate
     if: always()
-    needs: [install-validate, nested-simulation, nested-guest-install, windows-sanity, macos-sanity]
+    needs: [published-artifact-watch, install-validate, nested-simulation,
+            nested-guest-install, windows-sanity, macos-sanity]
     runs-on: ubuntu-latest
     steps:
-      - name: Results
+      # Iterates toJSON(needs) rather than naming one dependency. The previous
+      # body tested install-validate alone and then printed "All EoSim sanity
+      # checks passed" -- which it would do with the other four jobs red. This
+      # workflow has never had a green run, so the gate is about to start
+      # mattering for the first time; a summary that asserts more than it
+      # checked is the wrong thing to start with. This form cannot fall out of
+      # step with `needs:`.
+      - name: Every job in this workflow must have succeeded
+        env:
+          RESULTS: ${{ toJSON(needs) }}
         run: |
-          echo "════════════════════════════════════════════════"
-          echo "  EoSim Sanity Results"
-          echo "════════════════════════════════════════════════"
-          echo "Install & Validate (3 OS × 3 Py):  ${{ needs.install-validate.result }}"
-          echo "Nested Simulation (7 platforms):    ${{ needs.nested-simulation.result }}"
-          echo "Nested Guest Install (3 guests):    ${{ needs.nested-guest-install.result }}"
-          echo "Windows Sanity:                     ${{ needs.windows-sanity.result }}"
-          echo "macOS Sanity:                       ${{ needs.macos-sanity.result }}"
-          echo "════════════════════════════════════════════════"
-          if [ "${{ needs.install-validate.result }}" != "success" ]; then
-            echo "❌ Install/validate failed"; exit 1
+          printf '%s\n' "$RESULTS"
+          bad=$(printf '%s' "$RESULTS" | jq -r '
+            to_entries[]
+            | select(.value.result != "success")
+            | "  \(.key): \(.value.result)"')
+          if [ -n "$bad" ]; then
+            echo "::error::EoSim Sanity Gate failed. These jobs did not succeed:"
+            printf '%s\n' "$bad"
+            exit 1
           fi
-          echo "✅ All EoSim sanity checks passed"
+          echo "All EoSim sanity jobs succeeded."

--- a/.github/workflows/eosim-sanity.yml
+++ b/.github/workflows/eosim-sanity.yml
@@ -115,6 +115,15 @@ jobs:
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
           pip install "${{ runner.temp }}/EoSim"
+          # platforms/ is data, not package data: eosim/cli/main.py sets
+          # PLATFORMS_DIR to <site-packages>/platforms, while the package
+          # ships only eosim/platforms/__init__.py. Without this copy every
+          # `eosim run` fails with
+          #   FileNotFoundError: .../site-packages/platforms
+          # which is what the first real run of this workflow showed -- the
+          # missing v0.1.0 tag was the first blocker, not the only one.
+          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
+          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
       - name: Verify installation
         run: |
           eosim --version
@@ -158,6 +167,15 @@ jobs:
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
           pip install "${{ runner.temp }}/EoSim"
+          # platforms/ is data, not package data: eosim/cli/main.py sets
+          # PLATFORMS_DIR to <site-packages>/platforms, while the package
+          # ships only eosim/platforms/__init__.py. Without this copy every
+          # `eosim run` fails with
+          #   FileNotFoundError: .../site-packages/platforms
+          # which is what the first real run of this workflow showed -- the
+          # missing v0.1.0 tag was the first blocker, not the only one.
+          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
+          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
       - name: Simulate ${{ matrix.platform }}
         run: |
           eosim run ${{ matrix.platform }} --headless --timeout 10
@@ -187,6 +205,15 @@ jobs:
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
           pip install "${{ runner.temp }}/EoSim"
+          # platforms/ is data, not package data: eosim/cli/main.py sets
+          # PLATFORMS_DIR to <site-packages>/platforms, while the package
+          # ships only eosim/platforms/__init__.py. Without this copy every
+          # `eosim run` fails with
+          #   FileNotFoundError: .../site-packages/platforms
+          # which is what the first real run of this workflow showed -- the
+          # missing v0.1.0 tag was the first blocker, not the only one.
+          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
+          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
       - name: Boot guest and test EoSim inside
         run: |
           echo "=== Nested Guest: ${{ matrix.guest }} ==="
@@ -210,6 +237,15 @@ jobs:
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
           pip install "${{ runner.temp }}/EoSim"
+          # platforms/ is data, not package data: eosim/cli/main.py sets
+          # PLATFORMS_DIR to <site-packages>/platforms, while the package
+          # ships only eosim/platforms/__init__.py. Without this copy every
+          # `eosim run` fails with
+          #   FileNotFoundError: .../site-packages/platforms
+          # which is what the first real run of this workflow showed -- the
+          # missing v0.1.0 tag was the first blocker, not the only one.
+          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
+          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
           eosim --version
           # `eosim --version` is a hardcoded literal in EoSim
           # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it
@@ -242,6 +278,15 @@ jobs:
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
           pip install "${{ runner.temp }}/EoSim"
+          # platforms/ is data, not package data: eosim/cli/main.py sets
+          # PLATFORMS_DIR to <site-packages>/platforms, while the package
+          # ships only eosim/platforms/__init__.py. Without this copy every
+          # `eosim run` fails with
+          #   FileNotFoundError: .../site-packages/platforms
+          # which is what the first real run of this workflow showed -- the
+          # missing v0.1.0 tag was the first blocker, not the only one.
+          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
+          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
           eosim --version
           # `eosim --version` is a hardcoded literal in EoSim
           # (eosim/cli/main.py:49) and prints 2.0.0 from every tag, so it

--- a/.github/workflows/simulation-test.yml
+++ b/.github/workflows/simulation-test.yml
@@ -13,7 +13,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  EOSIM_VERSION: "0.1.0"
+  # embeddedos-org/EoSim has no v0.1.0 tag -- its releases run v1.0.0 to
+  # v3.0.1 -- so `git clone --branch v0.1.0` failed with "Remote branch
+  # v0.1.0 not found in upstream origin" on every run. v1.5.0 is the
+  # release marked Latest, and is what eosim-sanity.yml already pins.
+  EOSIM_VERSION: "1.5.0"
 
 jobs:
   simulate:

--- a/.github/workflows/simulation-test.yml
+++ b/.github/workflows/simulation-test.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install EoSim from source
+        # shell: bash -- the cross-platform matrix includes
+        # windows-latest, where the runner default is pwsh and the bash
+        # below is not valid. Same fix as eosim-sanity.yml; this file
+        # needed it too and the first two runs only reached it after the
+        # earlier blockers were cleared.
+        shell: bash
         run: |
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
@@ -84,6 +90,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install EoSim from source
+        # shell: bash -- the cross-platform matrix includes
+        # windows-latest, where the runner default is pwsh and the bash
+        # below is not valid. Same fix as eosim-sanity.yml; this file
+        # needed it too and the first two runs only reached it after the
+        # earlier blockers were cleared.
+        shell: bash
         run: |
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
@@ -95,6 +107,12 @@ jobs:
           SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
           cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
       - name: Validate all platforms
+        # shell: bash -- the cross-platform matrix includes
+        # windows-latest, where the runner default is pwsh and the bash
+        # below is not valid. Same fix as eosim-sanity.yml; this file
+        # needed it too and the first two runs only reached it after the
+        # earlier blockers were cleared.
+        shell: bash
         run: eosim list && eosim doctor
 
   sanity-gate:

--- a/.github/workflows/simulation-test.yml
+++ b/.github/workflows/simulation-test.yml
@@ -17,11 +17,14 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # embeddedos-org/EoSim has no v0.1.0 tag -- its releases run v1.0.0 to
-  # v3.0.1 -- so `git clone --branch v0.1.0` failed with "Remote branch
-  # v0.1.0 not found in upstream origin" on every run. v1.5.0 is the
-  # release marked Latest, and is what eosim-sanity.yml already pins.
+  # A SHA, not a tag, because EoSim's tag names do not identify their
+  # contents: the v1.5.0 tag installs a dist declaring 3.0.1, and the v3.0.1
+  # tag ships an __init__ claiming 2.0.0. This commit is what v1.5.0 resolved
+  # to on 2026-09-03; switch back to a tag once EoSim's tags mean something.
   EOSIM_COMMIT: "7dec3460cba76083b6645eb4a867e39aa2af97df"   # v1.5.0 as of 2026-09-03
+  # What that commit's pyproject.toml declares to pip; asserted by the
+  # install-eosim composite action.
+  EOSIM_EXPECTED_DIST: "3.0.1"
 
 jobs:
   simulate:
@@ -47,23 +50,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install EoSim from source
-        # shell: bash -- the cross-platform matrix includes
-        # windows-latest, where the runner default is pwsh and the bash
-        # below is not valid. Same fix as eosim-sanity.yml; this file
-        # needed it too and the first two runs only reached it after the
-        # earlier blockers were cleared.
-        shell: bash
-        run: |
-          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
-          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
-          pip install "${{ runner.temp }}/EoSim"
-          # See the note in eosim-sanity.yml: PLATFORMS_DIR resolves to
-          # <site-packages>/platforms and the package ships only
-          # eosim/platforms/__init__.py, so without this every `eosim run`
-          # fails with FileNotFoundError.
-          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
-          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
+      - name: Install EoSim (pinned)
+        uses: ./.github/actions/install-eosim
+        with:
+          commit: ${{ env.EOSIM_COMMIT }}
+          expected-dist: ${{ env.EOSIM_EXPECTED_DIST }}
       - name: Validate platform
         run: eosim list
       - name: Run simulation
@@ -89,23 +80,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install EoSim from source
-        # shell: bash -- the cross-platform matrix includes
-        # windows-latest, where the runner default is pwsh and the bash
-        # below is not valid. Same fix as eosim-sanity.yml; this file
-        # needed it too and the first two runs only reached it after the
-        # earlier blockers were cleared.
-        shell: bash
-        run: |
-          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
-          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
-          pip install "${{ runner.temp }}/EoSim"
-          # See the note in eosim-sanity.yml: PLATFORMS_DIR resolves to
-          # <site-packages>/platforms and the package ships only
-          # eosim/platforms/__init__.py, so without this every `eosim run`
-          # fails with FileNotFoundError.
-          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
-          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
+      - name: Install EoSim (pinned)
+        uses: ./.github/actions/install-eosim
+        with:
+          commit: ${{ env.EOSIM_COMMIT }}
+          expected-dist: ${{ env.EOSIM_EXPECTED_DIST }}
       - name: Validate all platforms
         # shell: bash -- the cross-platform matrix includes
         # windows-latest, where the runner default is pwsh and the bash
@@ -121,15 +100,28 @@ jobs:
     needs: [simulate, cross-platform]
     runs-on: ubuntu-latest
     steps:
-      - name: Results
+      # Iterates toJSON(needs) rather than naming one dependency: the
+      # previous body tested `simulate` alone and then printed "All
+      # simulation tests passed", which it would also do with all three
+      # cross-platform legs red. Same guards as eosim-sanity's gate; both
+      # should become a call to eos#121's ci-gate-check.sh once that lands.
+      - name: Every job in this workflow must have succeeded
+        env:
+          RESULTS: ${{ toJSON(needs) }}
         run: |
-          echo "════════════════════════════════════════════"
-          echo "  EoSim Simulation Test Results"
-          echo "════════════════════════════════════════════"
-          echo "Simulation (11 platforms):     ${{ needs.simulate.result }}"
-          echo "Cross-Platform (Win/Lin/Mac):  ${{ needs.cross-platform.result }}"
-          echo "════════════════════════════════════════════"
-          if [ "${{ needs.simulate.result }}" != "success" ]; then
-            echo "❌ Simulation failed"; exit 1
+          set -euo pipefail
+          if [ -z "${RESULTS:-}" ] || [ "$RESULTS" = "null" ]; then
+            echo "::error::gate received no results to check"
+            exit 1
           fi
-          echo "✅ All simulation tests passed"
+          printf '%s\n' "$RESULTS"
+          bad=$(printf '%s' "$RESULTS" | jq -r '
+            to_entries[]
+            | select(.value.result != "success")
+            | "  \(.key): \(.value.result)"')
+          if [ -n "$bad" ]; then
+            echo "::error::Simulation Gate failed. These jobs did not succeed:"
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+          echo "All simulation jobs succeeded."

--- a/.github/workflows/simulation-test.yml
+++ b/.github/workflows/simulation-test.yml
@@ -4,7 +4,11 @@ on:
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
-
+  # A change to this file tests itself; see the note in eosim-sanity.yml.
+  pull_request:
+    paths:
+      - '.github/workflows/simulation-test.yml'
+      - '.github/workflows/eosim-sanity.yml'
 permissions:
   contents: read
 
@@ -17,7 +21,7 @@ env:
   # v3.0.1 -- so `git clone --branch v0.1.0` failed with "Remote branch
   # v0.1.0 not found in upstream origin" on every run. v1.5.0 is the
   # release marked Latest, and is what eosim-sanity.yml already pins.
-  EOSIM_VERSION: "1.5.0"
+  EOSIM_COMMIT: "7dec3460cba76083b6645eb4a867e39aa2af97df"   # v1.5.0 as of 2026-09-03
 
 jobs:
   simulate:
@@ -45,8 +49,9 @@ jobs:
           python-version: "3.12"
       - name: Install EoSim from source
         run: |
-          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
-          pip install -e /tmp/EoSim
+          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
+          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
+          pip install "${{ runner.temp }}/EoSim"
       - name: Validate platform
         run: eosim list
       - name: Run simulation
@@ -74,8 +79,9 @@ jobs:
           python-version: "3.12"
       - name: Install EoSim from source
         run: |
-          git clone --depth 1 --branch v${{ env.EOSIM_VERSION }} https://github.com/embeddedos-org/EoSim.git /tmp/EoSim
-          pip install -e /tmp/EoSim
+          git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
+          git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
+          pip install "${{ runner.temp }}/EoSim"
       - name: Validate all platforms
         run: eosim list && eosim doctor
 

--- a/.github/workflows/simulation-test.yml
+++ b/.github/workflows/simulation-test.yml
@@ -52,6 +52,12 @@ jobs:
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
           pip install "${{ runner.temp }}/EoSim"
+          # See the note in eosim-sanity.yml: PLATFORMS_DIR resolves to
+          # <site-packages>/platforms and the package ships only
+          # eosim/platforms/__init__.py, so without this every `eosim run`
+          # fails with FileNotFoundError.
+          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
+          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
       - name: Validate platform
         run: eosim list
       - name: Run simulation
@@ -82,6 +88,12 @@ jobs:
           git clone --filter=blob:none https://github.com/embeddedos-org/EoSim.git "${{ runner.temp }}/EoSim"
           git -C "${{ runner.temp }}/EoSim" checkout --detach ${{ env.EOSIM_COMMIT }}
           pip install "${{ runner.temp }}/EoSim"
+          # See the note in eosim-sanity.yml: PLATFORMS_DIR resolves to
+          # <site-packages>/platforms and the package ships only
+          # eosim/platforms/__init__.py, so without this every `eosim run`
+          # fails with FileNotFoundError.
+          SITE_PACKAGES=$(python -c "import eosim, os; print(os.path.dirname(os.path.dirname(eosim.__file__)))")
+          cp -r "${{ runner.temp }}/EoSim/platforms" "$SITE_PACKAGES/"
       - name: Validate all platforms
         run: eosim list && eosim doctor
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,11 @@ add_executable(test_crypto_rsa test_crypto_rsa.c)
 target_link_libraries(test_crypto_rsa PRIVATE eos_crypto)
 add_test(NAME test_crypto_rsa COMMAND test_crypto_rsa)
 
+# --- test_crypto_ed25519_loworder: reject keys outside the prime-order subgroup ---
+add_executable(test_crypto_ed25519_loworder test_crypto_ed25519_loworder.c)
+target_link_libraries(test_crypto_ed25519_loworder PRIVATE eos_crypto)
+add_test(NAME test_crypto_ed25519_loworder COMMAND test_crypto_ed25519_loworder)
+
 # --- test_crypto_sha512: SHA-512 against NIST vectors ---
 add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)


### PR DESCRIPTION
> **Stacked on #127** so this branch is not red for the unrelated `test_crypto_ed25519_loworder` reason. Review the second commit.

`Simulation Test` and `EoSim Sanity` are both red on master. #106 fixed this class in `eosim-sanity.yml` but did not reach every site — there were two more, and they fail for two different reasons.

## 1. `simulation-test.yml` pins a tag that does not exist

```yaml
EOSIM_VERSION: "0.1.0"
```

EoSim has no `v0.1.0` tag — its releases run v1.0.0 to v3.0.1 — so every run failed at the clone:

```
fatal: Remote branch v0.1.0 not found in upstream origin
```

Bumped to `1.5.0`, the release marked Latest and the one `eosim-sanity.yml` already pins.

## 2. `eosim-sanity.yml` still installs a wheel on two legs

```
ERROR: HTTP error 404 while getting
  .../releases/download/v1.5.0/eosim-1.5.0-py3-none-any.whl
```

**No EoSim release ships a wheel at any version**, so a version bump alone could never have fixed these two — that is why they survived #106. The other three jobs in the same workflow already install from a clone; the Windows and macOS legs were missed. Converted to the identical clone + `pip install -e`.

## Verified against the real remote, not inferred from the error text

```
wheel URL                       ->  HTTP 404
git ls-remote --tags | v0.1.0   ->  0 matches
git ls-remote --tags | v1.5.0   ->  1 match

clone v1.5.0 + pip install -e   ->  rc 0
eosim --version                 ->  eosim, version 2.0.0
eosim doctor                    ->  rc 0
```

Both files still parse as YAML (3 and 6 jobs respectively).

One oddity worth recording rather than hiding: the `v1.5.0` tag reports its version as `2.0.0`. That is EoSim's own inconsistency, not a mis-pin — `v1.5.0` is what its releases page marks Latest, and it installs and runs cleanly.
