### PR TITLE
Fix task wake timeout at tick zero

### DIFF
--- a/kernel/src/task.c
+++ b/kernel/src/task.c
@@ -174,7 +174,9 @@ void eos_task_wake_check(uint32_t current_tick)
 {
     for (int i = 0; i < EOS_MAX_TASKS; i++) {
         eos_task_t *t = &g_tasks[i];
-        if (t->state == EOS_TASK_BLOCKED && t->wake_tick > 0 &&
+        /* wake_armed, not wake_tick > 0: a deadline of 0 is valid when
+         * g_tick + timeout wraps. WAIT_FOREVER leaves wake_armed clear. */
+        if (t->state == EOS_TASK_BLOCKED && t->wake_armed &&
             tick_expired(current_tick, t->wake_tick)) {
             t->state = EOS_TASK_READY;
             t->wake_armed = 0;

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -260,6 +260,42 @@ static void test_tick_overflow(void) {
     printf("[PASS] tick overflow wraparound\n");
 }
 
+static void test_wake_tick_zero(void) {
+    eos_kernel_init();
+
+    /* g_tick + 1 wraps to 0. wake_armed must still mark that deadline live. */
+    g_tick = 0xFFFFFFFFU;
+    int timed = eos_task_create("wrap0", test_entry, NULL, 5, 1024);
+    assert(timed >= 0);
+    eos_task_block_with_timeout((eos_task_handle_t)timed, 1);
+    assert(eos_task_get_state((eos_task_handle_t)timed) == EOS_TASK_BLOCKED);
+    assert(g_tasks[timed].wake_tick == 0);
+    assert(g_tasks[timed].wake_armed == 1);
+
+    /* One tick before wrap: not expired */
+    eos_task_wake_check(0xFFFFFFFFU);
+    assert(eos_task_get_state((eos_task_handle_t)timed) == EOS_TASK_BLOCKED);
+
+    /* Tick 0 is the deadline — must wake even though wake_tick is 0 */
+    eos_task_wake_check(0);
+    assert(eos_task_get_state((eos_task_handle_t)timed) == EOS_TASK_READY);
+
+    /* WAIT_FOREVER also stores wake_tick = 0, but wake_armed stays 0 */
+    int forever = eos_task_create("forever", test_entry, NULL, 5, 1024);
+    assert(forever >= 0);
+    eos_task_block_with_timeout((eos_task_handle_t)forever, EOS_WAIT_FOREVER);
+    assert(eos_task_get_state((eos_task_handle_t)forever) == EOS_TASK_BLOCKED);
+    assert(g_tasks[forever].wake_tick == 0);
+    assert(g_tasks[forever].wake_armed == 0);
+
+    eos_task_wake_check(0);
+    assert(eos_task_get_state((eos_task_handle_t)forever) == EOS_TASK_BLOCKED);
+    eos_task_wake_check(1);
+    assert(eos_task_get_state((eos_task_handle_t)forever) == EOS_TASK_BLOCKED);
+
+    printf("[PASS] wake_tick wrap to zero\n");
+}
+
 /* Mock port functions for host-based simulation/testing */
 uint32_t eos_port_enter_critical(void) { return 0; }
 void eos_port_exit_critical(uint32_t state) { (void)state; }
@@ -320,6 +356,7 @@ int main(void) {
     test_queue_full();
     test_task_stats();
     test_tick_overflow();
-    printf("=== ALL KERNEL TESTS PASSED (12/12) ===\n");
+    test_wake_tick_zero();
+    printf("=== ALL KERNEL TESTS PASSED (13/13) ===\n");
     return 0;
 }


### PR DESCRIPTION
Summary

Fixes task wake-up handling when a timeout deadline wraps around the 32-bit tick counter to 0.

Changes
Use wake_armed to determine whether a task has an active timeout instead of checking wake_tick > 0.
Add a regression test covering a timeout whose deadline wraps to tick 0.
Verify that EOS_WAIT_FOREVER tasks remain blocked when wake_tick is 0.
Testing
test_kernel: 13/13 tests passed
git diff --check: clean

