### PR TITLE
fix(kernel): preserve scheduler task invariants

### DIFF
--- a/kernel/include/eos/kernel_internal.h
+++ b/kernel/include/eos/kernel_internal.h
@@ -23,6 +23,19 @@ extern volatile uint32_t g_tick;
 /* Task array — accessible to sync.c and ipc.c for priority inheritance */
 extern eos_task_t g_tasks[EOS_MAX_TASKS];
 
+/* Stack-pointer slots shared with the architecture context-switch handler. */
+extern uint32_t **g_current_sp;
+extern uint32_t **g_next_sp;
+
+/**
+ * @brief Select the next runnable task during a context switch.
+ *
+ * The port saves the outgoing CPU stack pointer through g_current_sp before
+ * calling this function. On return, both stack-pointer slots identify the
+ * newly running task so the port can restore it and save it on the next switch.
+ */
+void eos_schedule(void);
+
 /**
  * @brief True once @p now has reached or passed @p deadline.
  *

--- a/kernel/src/arch/arm_cm/context_switch.S
+++ b/kernel/src/arch/arm_cm/context_switch.S
@@ -45,9 +45,9 @@ PendSV_Handler:
     str     r0, [r1]            /* Save PSP */
 
     /* ---- Select next task ---- */
-    push    {lr}
+    push    {r3, lr}            /* Preserve 8-byte AAPCS stack alignment */
     bl      eos_schedule        /* Updates g_current_sp and g_next_sp */
-    pop     {lr}
+    pop     {r3, lr}
 
     /* ---- Restore next context ---- */
     ldr     r1, =g_next_sp

--- a/kernel/src/task.c
+++ b/kernel/src/task.c
@@ -125,8 +125,8 @@ static int find_next_task(void)
     for (int i = 0; i < EOS_MAX_TASKS; i++) {
         int idx = (start + i) % EOS_MAX_TASKS;
         eos_task_t *t = &g_tasks[idx];
-        if (t->state != EOS_TASK_READY) continue;
-        if (t->priority < best_prio) {
+        if (t->entry == NULL || t->state != EOS_TASK_READY) continue;
+        if (best < 0 || t->priority < best_prio) {
             best_prio = t->priority;
             best = idx;
         }
@@ -141,15 +141,7 @@ static int find_next_task(void)
  */
 void eos_schedule(void)
 {
-    int next = find_next_task();
-    if (next < 0) return;  /* No ready tasks — stay on current */
-
-    /* Mark current task as ready (if it was running) */
-    if (g_current >= 0 && g_tasks[g_current].state == EOS_TASK_RUNNING) {
-        g_tasks[g_current].state = EOS_TASK_READY;
-    }
-
-    /* Check stack canary on current task */
+    /* Validate the outgoing task before making it eligible for selection. */
     if (g_current >= 0 && g_tasks[g_current].stack_base) {
         if (g_tasks[g_current].stack_base[0] != EOS_STACK_CANARY) {
             /* Stack overflow detected! */
@@ -158,12 +150,24 @@ void eos_schedule(void)
         }
     }
 
-    /* Switch to next task */
-    g_current_sp = &g_tasks[g_current >= 0 ? g_current : next].stack_ptr;
+    /* A preempted task remains runnable and competes at its normal priority. */
+    if (g_current >= 0 && g_tasks[g_current].state == EOS_TASK_RUNNING) {
+        g_tasks[g_current].state = EOS_TASK_READY;
+    }
+
+    int next = find_next_task();
+    if (next < 0) return;  /* No valid task is runnable. */
+
+    /*
+     * PendSV has already saved the outgoing PSP through g_current_sp.
+     * Point both assembly-facing slots at the task that is now current, so
+     * the next PendSV saves that task's PSP into its own control block.
+     */
     g_current = next;
     g_tasks[next].state = EOS_TASK_RUNNING;
     g_tasks[next].run_count++;
-    g_next_sp = &g_tasks[next].stack_ptr;
+    g_current_sp = &g_tasks[next].stack_ptr;
+    g_next_sp = g_current_sp;
 }
 
 /**
@@ -281,6 +285,8 @@ int eos_task_create(const char *name, eos_task_func_t entry, void *arg,
     if (!entry) return EOS_KERN_INVALID;
     if (stack_size == 0) stack_size = 1024;
 
+    uint32_t crit = eos_port_enter_critical();
+
     /* Find free slot (skip slot 0 = idle) */
     int slot = -1;
     for (int i = 1; i < EOS_MAX_TASKS; i++) {
@@ -290,30 +296,41 @@ int eos_task_create(const char *name, eos_task_func_t entry, void *arg,
             break;
         }
     }
-    if (slot < 0) return EOS_KERN_NO_MEMORY;
+    if (slot < 0) {
+        eos_port_exit_critical(crit);
+        return EOS_KERN_NO_MEMORY;
+    }
 
     /* Allocate stack */
     uint32_t *stack_base = alloc_task_stack(stack_size);
-    if (!stack_base) return EOS_KERN_NO_MEMORY;
+    if (!stack_base) {
+        eos_port_exit_critical(crit);
+        return EOS_KERN_NO_MEMORY;
+    }
 
     uint32_t *stack_top = stack_base + stack_size / sizeof(uint32_t);
 
     memset(&g_tasks[slot], 0, sizeof(eos_task_t));
+    g_tasks[slot].state = EOS_TASK_DELETED;
     g_tasks[slot].id = (uint8_t)slot;
     g_tasks[slot].name = name;
-    g_tasks[slot].entry = entry;
     g_tasks[slot].arg = arg;
     g_tasks[slot].priority = priority;
     g_tasks[slot].base_priority = priority;
     g_tasks[slot].stack_size = stack_size;
     g_tasks[slot].stack_base = stack_base;
     g_tasks[slot].stack_ptr = eos_port_init_stack(stack_top, entry, arg);
+
+    /* Publish the entry and READY state only after the TCB is complete. */
+    g_tasks[slot].entry = entry;
     g_tasks[slot].state = EOS_TASK_READY;
     g_task_count++;
 
     /* If kernel is running and new task has higher priority, yield */
-    if (g_running && g_current >= 0 &&
-        priority < g_tasks[g_current].priority) {
+    bool should_preempt = g_running && g_current >= 0 &&
+                          priority < g_tasks[g_current].priority;
+    eos_port_exit_critical(crit);
+    if (should_preempt) {
         eos_port_yield();
     }
 
@@ -322,7 +339,7 @@ int eos_task_create(const char *name, eos_task_func_t entry, void *arg,
 
 int eos_task_delete(eos_task_handle_t h)
 {
-    if (h >= EOS_MAX_TASKS) return EOS_KERN_INVALID;
+    if (h == 0 || h >= EOS_MAX_TASKS) return EOS_KERN_INVALID;
     if (g_tasks[h].state == EOS_TASK_DELETED || g_tasks[h].entry == NULL)
         return EOS_KERN_INVALID;
     g_tasks[h].state = EOS_TASK_DELETED;
@@ -337,7 +354,8 @@ int eos_task_delete(eos_task_handle_t h)
 
 int eos_task_suspend(eos_task_handle_t h)
 {
-    if (h >= EOS_MAX_TASKS || g_tasks[h].entry == NULL) return EOS_KERN_INVALID;
+    if (h == 0 || h >= EOS_MAX_TASKS || g_tasks[h].entry == NULL)
+        return EOS_KERN_INVALID;
     g_tasks[h].state = EOS_TASK_SUSPENDED;
     if (h == (eos_task_handle_t)g_current) {
         eos_port_yield();
@@ -572,5 +590,3 @@ int eos_task_get_all_stats(eos_task_stats_t *out, int max_entries, int *count)
     *count = n;
     return EOS_KERN_OK;
 }
-
-

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -9,7 +9,14 @@
 #include "eos/kernel_internal.h"
 
 static int g_task_ran = 0;
+static uint32_t g_critical_depth = 0;
+static void (*g_stack_init_hook)(void) = NULL;
 static void test_entry(void *arg) { g_task_ran = 1; (void)arg; }
+
+static void schedule_during_stack_init(void) {
+    assert(g_critical_depth > 0);
+    eos_schedule();
+}
 
 static void test_kernel_init(void) {
     assert(eos_kernel_init() == EOS_KERN_OK);
@@ -30,6 +37,74 @@ static void test_task_create_invalid(void) {
     eos_kernel_init();
     assert(eos_task_create("t", NULL, NULL, 5, 1024) == EOS_KERN_INVALID);
     printf("[PASS] task create invalid\n");
+}
+
+static void test_idle_task_is_permanent(void) {
+    eos_kernel_init();
+
+    assert(eos_task_get_state(0) == EOS_TASK_READY);
+    assert(strcmp(eos_task_get_name(0), "idle") == 0);
+    assert(eos_task_delete(0) == EOS_KERN_INVALID);
+    assert(eos_task_suspend(0) == EOS_KERN_INVALID);
+    assert(eos_task_get_state(0) == EOS_TASK_READY);
+    assert(strcmp(eos_task_get_name(0), "idle") == 0);
+
+    printf("[PASS] idle task cannot be deleted or suspended\n");
+}
+
+static void test_scheduler_selects_valid_task_and_tracks_stack(void) {
+    eos_kernel_init();
+
+    int first = eos_task_create("first", test_entry, NULL, 2, 512);
+    assert(first >= 0);
+
+    eos_task_set_current_internal((eos_task_handle_t)first);
+    g_current_sp = &g_tasks[first].stack_ptr;
+    g_next_sp = g_current_sp;
+    uint32_t *first_sp = g_tasks[first].stack_ptr;
+
+    /* Simulate a scheduling attempt during runtime task initialization. */
+    g_stack_init_hook = schedule_during_stack_init;
+    int second = eos_task_create("second", test_entry, NULL, 1, 512);
+    g_stack_init_hook = NULL;
+    assert(second >= 0);
+    assert(eos_task_get_current() == (eos_task_handle_t)first);
+    assert(eos_task_get_state((eos_task_handle_t)second) == EOS_TASK_READY);
+
+    eos_schedule();
+    assert(eos_task_get_state((eos_task_handle_t)first) == EOS_TASK_READY);
+    assert(eos_task_get_state((eos_task_handle_t)second) == EOS_TASK_RUNNING);
+    assert(g_current_sp == &g_tasks[second].stack_ptr);
+    assert(g_next_sp == &g_tasks[second].stack_ptr);
+
+    /* Simulate PendSV saving the current task's PSP before the next switch. */
+    uint32_t *second_sp = g_tasks[second].stack_ptr - 1;
+    *g_current_sp = second_sp;
+    assert(g_tasks[second].stack_ptr == second_sp);
+    assert(g_tasks[first].stack_ptr == first_sp);
+
+    /* A tick must not displace the highest-priority runnable task. */
+    eos_schedule();
+    assert(eos_task_get_state((eos_task_handle_t)first) == EOS_TASK_READY);
+    assert(eos_task_get_state((eos_task_handle_t)second) == EOS_TASK_RUNNING);
+    assert(g_current_sp == &g_tasks[second].stack_ptr);
+    assert(g_next_sp == &g_tasks[second].stack_ptr);
+
+    assert(eos_task_suspend((eos_task_handle_t)second) == EOS_KERN_OK);
+    eos_schedule();
+    assert(eos_task_get_state((eos_task_handle_t)first) == EOS_TASK_RUNNING);
+    assert(g_current_sp == &g_tasks[first].stack_ptr);
+    assert(g_next_sp == &g_tasks[first].stack_ptr);
+
+    /* Priority 255 is valid and must allow the idle fallback to run. */
+    assert(eos_task_suspend((eos_task_handle_t)first) == EOS_KERN_OK);
+    assert(eos_task_delete((eos_task_handle_t)second) == EOS_KERN_OK);
+    eos_schedule();
+    assert(eos_task_get_state(0) == EOS_TASK_RUNNING);
+    assert(g_current_sp == &g_tasks[0].stack_ptr);
+    assert(g_next_sp == &g_tasks[0].stack_ptr);
+
+    printf("[PASS] scheduler selects valid task and tracks its stack\n");
 }
 
 static void test_task_delete(void) {
@@ -261,8 +336,15 @@ static void test_tick_overflow(void) {
 }
 
 /* Mock port functions for host-based simulation/testing */
-uint32_t eos_port_enter_critical(void) { return 0; }
-void eos_port_exit_critical(uint32_t state) { (void)state; }
+uint32_t eos_port_enter_critical(void) {
+    uint32_t previous = g_critical_depth;
+    g_critical_depth++;
+    return previous;
+}
+void eos_port_exit_critical(uint32_t state) {
+    assert(g_critical_depth > 0);
+    g_critical_depth = state;
+}
 
 /* Captures owner priority at yield so tests can observe PI boost mid-lock. */
 static int g_yield_owner = -1;
@@ -274,7 +356,12 @@ void eos_port_yield(void)
     if (q7_yield_hook) q7_yield_hook();
 }
 void eos_port_start_scheduler(void) {}
-uint32_t *eos_port_init_stack(uint32_t *s, void (*e)(void*), void *a) { (void)e; (void)a; return s - 17; }
+uint32_t *eos_port_init_stack(uint32_t *s, void (*e)(void*), void *a) {
+    (void)e;
+    (void)a;
+    if (g_stack_init_hook) g_stack_init_hook();
+    return s - 17;
+}
 void eos_port_start_first_task(void) {}
 
 static void test_mutex_pi_timeout_restores_priority(void) {
@@ -311,6 +398,8 @@ int main(void) {
     test_kernel_init();
     test_task_create();
     test_task_create_invalid();
+    test_idle_task_is_permanent();
+    test_scheduler_selects_valid_task_and_tracks_stack();
     test_task_delete();
     test_task_suspend_resume();
     test_mutex();
@@ -320,6 +409,6 @@ int main(void) {
     test_queue_full();
     test_task_stats();
     test_tick_overflow();
-    printf("=== ALL KERNEL TESTS PASSED (12/12) ===\n");
+    printf("=== ALL KERNEL TESTS PASSED (14/14) ===\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

This PR fixes task selection and stack-pointer bookkeeping in the Cortex-M scheduler, and protects the kernel-owned idle task. I chose these two areas for the technical assessment after reviewing task creation, scheduling, and the PendSV save/restore sequence.

On the base commit (`feee272`), unused task slots are zero-initialized, which makes them appear `READY` at priority 0. The scheduler can therefore select an empty slot over a real task and hand the restore path a null stack pointer. Separately, `g_current_sp` keeps pointing at the outgoing task after a switch. On the following PendSV, the running task's stack pointer would be saved into the previous task's control block.

The scheduler now selects initialized, runnable tasks and keeps the stack-pointer slot aligned with the task actually running. It also keeps a preempted task eligible at its own priority and allows priority 255, so idle can run when application tasks are blocked.

## Before and after

The [review of this commit](https://github.com/embeddedos-org/eos/pull/131#pullrequestreview-5104656159) independently reproduced the selection failures using host probes:

| Scenario | Base (`feee272`) | This PR (`e291bee`) |
| --- | --- | --- |
| Initialize the kernel, create one task at priority 5, then call `eos_schedule()` | Selects empty slot 2: `name=invalid`, `stack_ptr=(nil)` | Selects the real task in slot 1 with a non-null saved stack pointer |
| Block all application tasks | Selects an empty slot instead of idle; the strict priority comparison also excludes priority 255 | Selects slot 0: `name=idle` |

For the stack-pointer handoff, tracing A → B → A shows that the old code leaves `g_current_sp` pointing at A after selecting B. This PR updates it to B before returning, so the next save goes to B's own TCB. The host regression simulates that save and checks that A's saved pointer is unchanged. Execution of the ARM handler itself remains unverified, as noted below.

## Type of change

- [x] fix — Bug fix
- [x] test — Add regression tests

## Implementation

- Reject deletion and suspension of the idle task in reserved slot 0 with `EOS_KERN_INVALID`.
- Exclude slots with a null entry function and accept priority 255 during task selection.
- Check the outgoing task's canary before selection, and keep a still-running task eligible alongside other runnable tasks. Equal-priority round-robin ordering is preserved.
- Point both `g_current_sp` and `g_next_sp` at the selected task's saved stack-pointer slot, and document the C/assembly contract in `kernel_internal.h`.
- Protect slot selection, static stack allocation, and TCB initialization with a critical section. Publish the entry function and `READY` state after initialization, restore the previous interrupt state on every exit, and request preemption after leaving the critical section.
- Use `push {r3, lr}` / `pop {r3, lr}` around the call to `eos_schedule()` to preserve 8-byte stack alignment at the C call boundary.
- Add regression coverage for idle protection, scheduling during task initialization, priority retention, consecutive stack-pointer handoffs, and idle fallback.

Public function signatures and task structure layout are unchanged. The intentional API behavior change is that deleting or suspending the idle task is now rejected.

## Testing

Results for commit `e291bee` on the macOS ARM64 host:

- Kernel test executable: **14/14 passed**.
- Existing registered host suite, Debug build: **38/38 passed**.
- Existing registered host suite with AddressSanitizer and UndefinedBehaviorSanitizer: **38/38 passed** (`detect_leaks=0`).
- Release library build: **passed**.
- Strict C11 compilation of `task.c`: **passed**.
- Cortex-M4 assembly compilation of `context_switch.S`: **passed**.

The reviewer independently reproduced the 14/14 kernel and 38/38 host/sanitizer results. The new tests exercise scheduler behavior through the host port mocks; they do not execute real interrupt masking or ARM exception entry/return.

## Validation still needed

At the time of this description update, GitHub reports no checks for this PR. Maintainer approval of the fork workflow runs is needed before relying on CI results.

The current QEMU boot job omits `context_switch.S` and `systick.c`, and its system test does not call `eos_kernel_start()`. Neither the host tests nor the assembly compilation demonstrate a running PendSV context switch. A QEMU or hardware test that starts the scheduler and performs repeated handoffs is still needed to validate that path end to end.

## Related issues

No issue is linked; these changes came from the assessment code review. The commit follows the conventional commit format and includes a DCO sign-off.
