### PR TITLE
ci: pin the eBoot and ebuild checkouts instead of floating on master

### DIFF
--- a/.github/workflows/eos-simulation.yml
+++ b/.github/workflows/eos-simulation.yml
@@ -9,6 +9,15 @@ on:
 
 env:
   EOS_VERSION: "0.6.0"
+  # The kernel job compiles eBoot and checks out ebuild. Those used to float on
+  # `ref: master`, so the moment either repo's master stopped compiling, every
+  # open eos PR went red for a reason no eos change caused and no eos change
+  # could fix (2026-09-03: eBoot master's eos_image.h asserts a member that no
+  # longer exists, and its ed25519_verify.c has a redefined helper -- eBoot #94
+  # repairs it). A dependency is pinned and bumped deliberately; when eBoot #94
+  # lands, bump EBOOT_COMMIT to that merge and CI will say whether it holds.
+  EBOOT_COMMIT: "a172a6d6e1e66877413ed546401a65ee4f4f90db"
+  EBUILD_COMMIT: "e5d8052f3e2cfdcb1c91bab8300087aa07e02679"
   CROSS_COMPILE: "aarch64-linux-gnu-"
   QEMU_MACHINE: "virt"
   QEMU_CPU: "cortex-a57"
@@ -29,14 +38,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/eBoot
-          ref: master
+          ref: ${{ env.EBOOT_COMMIT }}
           path: eBoot
 
       - name: Checkout ebuild
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/ebuild
-          ref: master
+          ref: ${{ env.EBUILD_COMMIT }}
           path: ebuild
 
       # embeddedos-org/eFab does not exist -- the checkout 404s and takes this
@@ -276,7 +285,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embeddedos-org/ebuild
-          ref: master
+          ref: ${{ env.EBUILD_COMMIT }}
 
       # Same missing repository as in build-kernel.
       # - name: Checkout eFab

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,146 @@
+name: Upstream drift
+
+# EoS Full-Stack Simulation compiles eBoot and checks out ebuild at pinned
+# commits rather than at `master`, so that no eos pull request can be turned
+# red by a break it did not cause. That pin has a cost: an eBoot master which
+# stops compiling becomes invisible from here, and the pin itself would sit
+# where it is indefinitely, because nothing would ever ask.
+#
+# This workflow is the other half of that trade. It builds eBoot at master and
+# compares both pins against their master, so an upstream break still surfaces
+# -- loudly, attributed to the repository responsible, and on a run that blocks
+# no pull request.
+#
+# It deliberately does not trigger on `pull_request`, and it lives in its own
+# file rather than as a skipped job inside the simulation workflow: a skipped
+# check still appears on every PR, and a required-check gate that treats any
+# non-success as a failure would then trip on it.
+#
+# It is deliberately not `continue-on-error`. A job that reports success over a
+# failure is the fail-open shape this repository keeps filing against; this one
+# is free to fail honestly precisely because it gates nothing.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: "Upstream drift (eBoot/ebuild master)"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout eos
+        uses: actions/checkout@v4
+        with:
+          path: eos
+
+      - name: Checkout eBoot at master
+        uses: actions/checkout@v4
+        with:
+          repository: embeddedos-org/eBoot
+          ref: master
+          path: eBoot
+          fetch-depth: 0
+
+      - name: Checkout ebuild at master
+        uses: actions/checkout@v4
+        with:
+          repository: embeddedos-org/ebuild
+          ref: master
+          path: ebuild
+          fetch-depth: 0
+
+      - name: Read the pins from the simulation workflow
+        id: pins
+        run: |
+          # One source of truth: the pins live in eos-simulation.yml and are
+          # read out of it here. If that ever stops parsing -- renamed key,
+          # moved file, reformatted value -- this fails rather than quietly
+          # checking a pin of "".
+          wf="eos/.github/workflows/eos-simulation.yml"
+          for key in EBOOT_COMMIT EBUILD_COMMIT; do
+            val=$(sed -n "s/^[[:space:]]*${key}:[[:space:]]*\"\([0-9a-f]\{40\}\)\".*/\1/p" "$wf" | head -1)
+            if [ -z "$val" ]; then
+              echo "::error::could not read $key as a 40-character SHA from $wf. The pin may have been renamed or reformatted; this job cannot report drift against a pin it cannot find."
+              exit 1
+            fi
+            echo "${key}=${val}" >> "$GITHUB_OUTPUT"
+            echo "read ${key}=${val}"
+          done
+
+      - name: Report how far each pin is behind master
+        env:
+          EBOOT_COMMIT: ${{ steps.pins.outputs.EBOOT_COMMIT }}
+          EBUILD_COMMIT: ${{ steps.pins.outputs.EBUILD_COMMIT }}
+        run: |
+          {
+            echo "### Pinned dependency drift"
+            echo
+            echo "eBoot is built at master below. ebuild is compared only --"
+            echo "the simulation workflow checks it out but does not build it."
+            echo
+            echo "| repository | pinned | master | commits behind |"
+            echo "| --- | --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for repo in eBoot ebuild; do
+            case "$repo" in
+              eBoot)  pin="$EBOOT_COMMIT" ;;
+              ebuild) pin="$EBUILD_COMMIT" ;;
+            esac
+            head=$(git -C "$repo" rev-parse HEAD)
+            if git -C "$repo" cat-file -e "${pin}^{commit}" 2>/dev/null; then
+              behind=$(git -C "$repo" rev-list --count "${pin}..HEAD")
+            else
+              behind="unknown"
+            fi
+            echo "| $repo | ${pin:0:9} | ${head:0:9} | $behind |" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$behind" = "unknown" ]; then
+              echo "::warning::$repo pin ${pin:0:9} is not an ancestor of master -- it may have been force-pushed away. Check it before bumping."
+            elif [ "$behind" != "0" ]; then
+              echo "::warning::$repo is pinned $behind commit(s) behind master. Bump it once this run shows master building."
+            fi
+          done
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            gcc-aarch64-linux-gnu \
+            binutils-aarch64-linux-gnu \
+            libc6-dev-arm64-cross \
+            cmake \
+            ninja-build
+
+      - name: Build eBoot at master
+        id: eboot
+        run: |
+          # The same configuration eos-simulation.yml builds the pin with, so
+          # a pass here means the pin can be bumped to this master.
+          cd eBoot
+          cmake -B build_drift -S . \
+            -DCMAKE_TOOLCHAIN_FILE=toolchains/aarch64-linux-gnu.cmake \
+            -DEBLDR_BOARD=qemu_arm64 \
+            -DEBLDR_VERIFY_STAGE1=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build_drift --parallel "$(nproc)"
+
+      - name: Say what a failure here means
+        # Scoped to the build step's own outcome. A checkout, apt or pin-read
+        # failure is an infrastructure or configuration problem, and must not
+        # report itself as evidence about eBoot's master.
+        if: failure() && steps.eboot.outcome == 'failure'
+        run: |
+          {
+            echo
+            echo "**embeddedos-org/eBoot@master does not build.**"
+            echo
+            echo "No eos pull request is affected -- the simulation jobs build the"
+            echo "pinned commit, not master. This is a defect in eBoot and has to"
+            echo "be repaired there before the pin can be bumped."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::eBoot master does not build. eos PRs are unaffected (they build the pin); fix eBoot, then bump EBOOT_COMMIT in eos-simulation.yml."

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,11 @@ add_executable(test_crypto_rsa test_crypto_rsa.c)
 target_link_libraries(test_crypto_rsa PRIVATE eos_crypto)
 add_test(NAME test_crypto_rsa COMMAND test_crypto_rsa)
 
+# --- test_crypto_ed25519_loworder: reject keys outside the prime-order subgroup ---
+add_executable(test_crypto_ed25519_loworder test_crypto_ed25519_loworder.c)
+target_link_libraries(test_crypto_ed25519_loworder PRIVATE eos_crypto)
+add_test(NAME test_crypto_ed25519_loworder COMMAND test_crypto_ed25519_loworder)
+
 # --- test_crypto_sha512: SHA-512 against NIST vectors ---
 add_executable(test_crypto_sha512 test_crypto_sha512.c)
 target_link_libraries(test_crypto_sha512 PRIVATE eos_crypto)


### PR DESCRIPTION
## What every red eos PR has in common

All 12 other open eos PRs fail `EoS Full-Stack Simulation`, and none of them caused it. Verified per PR rather than assumed: the same `error: 'eos_image_header_t' has no member named 'reserved'` on every one. The kernel job checks out `embeddedos-org/eBoot` at `ref: master`, and eBoot master does not compile — `include/eos_image.h:135`/`142` assert `offsetof(eos_image_header_t, reserved)` for a member that became `tlv_len` + `tlv_hash`, and `core/ed25519_verify.c` redefines `point_is_identity`. Two pairs of PRs that merged clean and broke the build together; eBoot #94 repairs it and waits on review. Until it lands, no change to any eos PR can turn this job green — and after it lands, the next broken eBoot master does the same thing to every open PR again.

## The change

Pin the two compiled-against checkouts to recorded SHAs, set in one `env:` block:

- `EBOOT_COMMIT = a172a6d6e1e6` — the newest eBoot master ancestor that compiles. Found by walking master backwards and **building each candidate**, not by reading history: `abd4dab` already fails (the ed25519 redefinition entered at `8a015b2`, its child).
- `EBUILD_COMMIT = e5d8052f3e2c` — ebuild's current master, frozen as-is. Both ebuild checkouts feed steps that are commented out (eFab does not exist), so this pin removes the float and changes nothing else.

The middleware matrix (10 repos) still floats deliberately: those jobs run each repo's own tests rather than compiling eos against them, and 10 more pins deserve their own decision.

This is the dependency rule `.ai/platform.md` already states — a consumer depends on a version, not on the moving head of another repo's tree. When eBoot #94 merges, bump `EBOOT_COMMIT` to the merge SHA; the bump is a one-line diff that gets its own CI run.

## The other half: the pin must not go stale silently

A pin alone makes the trade worse in one direction. Today an eBoot master that does not compile turns 12 eos PRs red — loud, attributable, useless. With the pin it turns nothing red, and **eos stops being able to see it at all**. The pin would then sit at `a172a6d` indefinitely, because nothing would ever ask, while it silently drops the 6 eBoot commits that follow it (#57, #76, #87, #91, #92, #93 — real security fixes among them).

So the pin ships with **`.github/workflows/upstream-drift.yml`**, which builds eBoot at `master` and compares both pins against their master:

- **Its own workflow file, on a schedule (`17 6 * * *`) and `workflow_dispatch` — never `pull_request`.** A PR must not be red for a break it did not cause; that is the entire point of the pin. The first draft was a job inside `eos-simulation.yml` guarded by `if: github.event_name == 'schedule'` — and the run showed it on the PR as a **`SKIPPED` check**. A required-check gate that treats any non-success as a failure, which is the design in #121, would trip on exactly that. Its own file removes it from PR runs entirely, rather than relying on every future gate to remember to exempt it.
- **Not `continue-on-error`.** A job that reports success over a failure is the fail-open shape this repo keeps filing against (`.ai/reviewer.md`; the aggregating gates in #121). This one is free to fail honestly *because it gates nothing*.
- **Failing is reserved for "upstream does not build."** A pin merely behind a healthy master is a `::warning::` plus a step-summary row — actionable, not broken.
- **The pins are read out of `eos-simulation.yml`, not copied.** A second copy of a SHA is a second thing to forget. The read demands a 40-character hex value and **fails closed** if it cannot find one, so a renamed or reformatted key stops the job rather than letting it silently check a pin of `""`.
- The failure message is scoped to `steps.eboot.outcome`, so a checkout, apt or pin-read failure cannot report itself as evidence about eBoot's master. The summary states plainly that **eBoot is built and ebuild is only compared**, rather than implying both were checked.

Net effect: an eos PR can no longer go red for another repository's break, and an upstream break is still loud — on a run that blocks nobody and names the repository responsible.

## Validation of the drift job (before pushing)

Run against the real repositories, not reasoned about:

| case | result |
|---|---|
| eBoot @ `a172a6d` (the pin), host build | **rc=0, 0 errors** |
| eBoot @ `22d8f8b` (master), host build | **rc=2** — `no member named 'reserved'` at `eos_image.h:135` and `:142`, the same defect CI reports |
| pin extraction, real workflow file | both SHAs read; the eBoot one resolves to #86's merge |
| pin extraction, key renamed to `EBOOT_SHA` | **fails closed, rc=1** |
| pin extraction, value unquoted and shortened | **fails closed, rc=1** |
| drift logic, pin 6 behind a healthy master | "behind by 6" warning, **no failure** |
| drift logic, pin absent from master | "not an ancestor" warning, **exit 0 under `set -e`** |
| drift logic, pin equal to master | no warning |
| both workflow YAMLs parse; drift has 8 steps | ✓ |
| eos on this branch: `cmake --build` / `ctest` / `pytest` | **rc=0 / 39 of 39 / 15 of 15**, with the new workflow file present |

The first draft of the missing-pin branch printed `pinned pin not found on master commit(s) behind` — caught by running that branch rather than reading it, and rewritten into its own message.


## Validation of the pin (before pushing)

| check | result |
|---|---|
| eBoot@`master`, job's own config (`qemu_arm64`, `VERIFY_STAGE1=OFF`, Release, cross) | **fails** — the exact `eos_image.h` assert errors from the job log |
| eBoot@`a172a6d`, same config, full build | **rc=0, every target** |
| Both pinned SHAs reachable from their repos' master | ✓ |
| Workflow YAML parses; diff is the env block + three `ref:` lines | ✓ |

The live test is this PR's own simulation run: it uses this branch's workflow, so it should go green while every master-based PR stays red on that job. If it does not, the pin is wrong and this PR should not merge.

Findings labels: the two eBoot master defects and the walk to `a172a6d` are **Verified** (built locally, negative and positive controls); the claim that a merged eBoot #94 stays green under this job is **Inferred** until its SHA exists to pin.
