### PR TITLE
docs(governance): community rollout for eos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,6 +47,11 @@
 <!-- Reference related issues: Closes #XX, Fixes #YY -->
 
 
+## Closing issue
+
+Fixes #<same-repository issue number>
+
+
 ## Screenshots / Logs
 
 <!-- If applicable, add screenshots or relevant log output -->

--- a/.github/workflows/linked-issue.yml
+++ b/.github/workflows/linked-issue.yml
@@ -1,0 +1,16 @@
+name: Linked issue policy
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  policy:
+    uses: embeddedos-org/.github/.github/workflows/linked-issue-policy.yml@92cb596c773496ec4df76717e8acf0e6b7700f73
+    with:
+      policy_ref: 92cb596c773496ec4df76717e8acf0e6b7700f73

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,98 +1,98 @@
-<!-- generated: eos-ai-scaffold -->
-# Agent Responsibilities
+# AGENTS.md — EoS
 
-Each role owns a slice of the work and does only that slice. Full briefs are in
-[.ai/](./.ai/). These are responsibilities, not a required agent count — one
-agent may hold several roles on a small change. Split when the roles need
-genuinely different context, not by default.
+EoS (CMake project `EoS`, v0.5.0) is a multi-platform embedded OS framework
+written in pure C11: a lightweight RTOS kernel, a hardware abstraction layer
+(HAL) with host (Linux) and bare-metal backends, a driver framework, and
+networking, power-management, and runtime-service layers. Board/product
+selection happens at configure time via descriptors in `boards/` and profiles
+in `products/`. (Provenance: `README.md` intro.)
 
-One rule is structural rather than stylistic: **whoever implements does not
-approve.** Review is a separate role because self-review reliably misses the
-thing the implementer already believes is correct.
+## Layout (from `README.md` "What's inside")
 
-## Planner — [.ai/planner.md](./.ai/planner.md)
+- `kernel/` — tasks, sync primitives, IPC, multicore — builds `eos_kernel`
+- `hal/` — HAL platform split (`hal_linux.c` / `hal_rtos.c`, plus `hal_win32.c`)
+  — builds `eos_hal`
+- `drivers/` — driver framework and the `devicetree/` parser — builds
+  `eos_drivers`
+- `net/` — networking abstraction (POSIX backend on host builds; bare-metal
+  `eos_net_connect()` returns `-1`) — builds `eos_net`
+- `power/` — power-management abstraction — builds `eos_power`
+- `core/` — OS config, logging, layer plumbing
+- `services/` — runtime services: `crypto`, `security`, `os`, `linux`, `gps`,
+  `motor`, `ota`, `filesystem`, `sensor`, `ui`, `init`, and more
+- `systems/` — rootfs, image, and firmware assembly
+- `boards/` — board descriptor files (`boards/*.yaml`) plus linker scripts
+- `products/` — product-profile headers selected by `EOS_PRODUCT`
+- `layers/`, `toolchains/`, `cmake/` — layer definitions, cross-compile
+  toolchain files, CMake helpers
+- `backends/`, `sim/`, `pkg/`, `debug/` — backend registry, simulation,
+  packaging, debug (GDB stub, core dump)
+- `examples/` — example apps (`blink-gpio`, `ble-sensor`, …)
+- `tests/` — C unit tests plus `functional/`, `fuzz/`, `performance/`,
+  `simulation/`
+- `docs/` — full documentation set (`mkdocs.yml`); API docs via `Doxyfile`
 
-- Understand the request.
-- Break work into tasks.
-- Assign work.
+## Build (from `README.md` "Build" and `CONTRIBUTING.md` "Development Setup")
 
-## Architect — [.ai/architect.md](./.ai/architect.md)
+Requires CMake ≥ 3.16 and a C11 compiler (GCC/Clang; MSVC on Windows). Native
+host build:
 
-- Design structure.
-- Choose patterns.
-- Own dependencies, scalability and maintainability.
+```bash
+cmake -B build/host -DCMAKE_BUILD_TYPE=Release
+cmake --build build/host --parallel
+```
 
-## Backend — [.ai/backend.md](./.ai/backend.md)
+Build options: `EOS_BUILD_TESTS` (default `OFF`), `EOS_PLATFORM`
+(`linux` | `rtos`, default `linux`), `EOS_PRODUCT` (one of the product
+profiles; empty = full build).
 
-- APIs
-- Database
-- Business logic
+Cross-compile for a target board with a toolchain file:
 
-## Frontend — [.ai/frontend.md](./.ai/frontend.md)
+```bash
+cmake -B build/arm -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-cortex-m4.cmake \
+  -DEOS_BUILD_TESTS=OFF
+cmake --build build/arm --parallel
+```
 
-- UI
-- Components
-- Accessibility
+## Test (from `README.md` "Test" and `CONTRIBUTING.md` "Development Setup")
 
-## Testing — [.ai/testing.md](./.ai/testing.md)
+`EOS_PRODUCT=vbox_test` is required alongside `EOS_BUILD_TESTS=ON`: the OTA,
+sensor, motor, and power tests only compile against a product profile that
+enables those services, and `vbox_test` is the profile meant for host-side
+testing.
 
-- Unit tests
-- Integration tests
-- Regression tests
+```bash
+cmake -B build/host -DEOS_BUILD_TESTS=ON -DEOS_PRODUCT=vbox_test
+cmake --build build/host --parallel
+ctest --test-dir build/host --output-on-failure
+python run_all_tests.py
+```
 
-## Security — [.ai/security.md](./.ai/security.md)
+Python tooling setup: `pip install -r requirements-dev.txt` (installs `pytest`
+and `pytest-cov`). `run_all_tests.py` runs pytest over `tests/unit`,
+`tests/functional`, `tests/performance`, and `tests/simulation`; direct run:
+`python -m pytest tests/ -v`.
 
-- Authentication and authorization
-- Validation
-- Secrets
-- Dependency review
+## Lint / format
 
-## Performance — [.ai/performance.md](./.ai/performance.md)
+Not defined: no lint or format command is documented in `README.md` or
+`CONTRIBUTING.md`. (A `.clang-format` and a `.clang-tidy` config file exist in
+the tree, and `ci.yml` runs a cppcheck + clang-tidy static-analysis job, but
+the repo documents no command to invoke a formatter or linter locally; C style
+rules — C11, `-Wall -Wextra` clean, `eos_` prefix, Doxygen doc comments — are
+in `CONTRIBUTING.md` "Code Guidelines".)
 
-- Profiling
-- Optimization
-- Scalability
+## Contributing
 
-## Reviewer — [.ai/reviewer.md](./.ai/reviewer.md)
+See `CONTRIBUTING.md`: fork, create a feature branch (`git checkout -b
+feat/my-feature`), run the build and tests locally, then submit a pull request.
+Follow Conventional Commits; the PR checklist requires zero-warning compiles on
+GCC, Clang, and MSVC, passing tests, HAL stubs for new peripherals,
+`#ifdef` platform guards, no GCC-only builtins without portable fallbacks, and
+no hardcoded filesystem paths.
 
-- Final review
-- Verify requirements
-- Merge findings
+## Security
 
-## Documentation — [.ai/docs.md](./.ai/docs.md)
-
-- README
-- API docs
-- Changelog
-- Migration and architecture notes
-
-## Release — [.ai/release.md](./.ai/release.md)
-
-- Release notes
-- Deployment preparation
-- Rollback guidance
-
----
-
-## Switching roles
-
-Switch when the task changes domain, when specialist knowledge is required,
-when independent review is required, or when the context has grown past what
-one agent can hold accurately. Every switch runs the protocol in
-[HANDOFF.md](./HANDOFF.md).
-
-## Finding work that is not yours
-
-You will. The rule is: **record it, do not absorb it, do not drop it.**
-
-| What you found | Do |
-|----------------|-----|
-| A defect unrelated to your task | Note it in [TASKS.md](./TASKS.md) and keep going. |
-| A defect your change would sit on top of | Stop; say it blocks you; propose fixing it as its own task. |
-| A security issue | Report immediately, whatever role you hold. This one never waits for a handoff. |
-| A design decision missing from the plan | Return to the architect rather than deciding it inside an implementation. |
-| Work that belongs to a role nobody assigned | Say so. An unowned task is how requirements go missing. |
-
-Silently fixing something outside your task makes the diff unreviewable.
-Silently ignoring it means nobody ever looks again. Neither is acceptable; the
-note is what makes the difference.
+See `SECURITY.md`. Report vulnerabilities to security@embeddedos.org — do NOT
+open public issues for vulnerabilities. Response within 48 hours.

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,0 +1,55 @@
+# Development
+
+## Contribution source of truth
+
+[CONTRIBUTING](https://github.com/embeddedos-org/eos/blob/master/CONTRIBUTING.md)
+
+Before proposing a change, also review the [README](https://github.com/embeddedos-org/eos/blob/master/README.md). Keep changes scoped, add tests appropriate to the affected behavior, and follow the repository's current automation and review requirements.
+
+## Build and dependency inputs found
+
+`CMakeLists.txt`, `Dockerfile`, `backends/CMakeLists.txt`, `cmd/eos/CMakeLists.txt`, `core/CMakeLists.txt`, `debug/CMakeLists.txt`, `drivers/devicetree/CMakeLists.txt`, `examples/ble-sensor/CMakeLists.txt`, `examples/blink-gpio/CMakeLists.txt`, `examples/hmi-panel/CMakeLists.txt`, `examples/multicore-amp/CMakeLists.txt`, `examples/multitask-rtos/CMakeLists.txt`, and 31 more.
+
+## Tests found in the default-branch tree
+
+`products/vbox_test.h`, `tests/CMakeLists.txt`, `tests/__init__.py`, `tests/assertions_enabled.h`, `tests/functional/__init__.py`, `tests/functional/test_functional_e2e.py`, `tests/functional/test_gps_driver.py`, `tests/fuzz/CMakeLists.txt`, `tests/fuzz/fuzz_aes.c`, `tests/fuzz/fuzz_devicetree.c`, `tests/fuzz/fuzz_ota_header.c`, `tests/fuzz/fuzz_sha256.c`, and 61 more.
+
+## Documented test commands
+
+These commands are reproduced from the inspected root README or contributing guide:
+
+```bash
+cmake -B build/host -DCMAKE_BUILD_TYPE=Release
+```
+
+```bash
+cmake --build build/host --parallel
+```
+
+```bash
+cmake -B build/arm -G Ninja \
+```
+
+```bash
+cmake --build build/arm --parallel
+```
+
+```bash
+cmake -B build/host -DEOS_BUILD_TESTS=ON -DEOS_PRODUCT=vbox_test
+```
+
+```bash
+ctest --test-dir build/host --output-on-failure
+```
+
+```bash
+cmake -B build -DEOS_BUILD_TESTS=ON -DEOS_PRODUCT=vbox_test
+```
+
+```bash
+cmake --build build
+```
+
+## Verification baseline
+
+This inventory comes from `master` at [`d14b62f62d2e`](https://github.com/embeddedos-org/eos/commit/d14b62f62d2ed7a0393d1d99e433949cdca76973) and found 73 test-related paths among 796 files. Re-check the source tree when that commit is no longer current.

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,0 +1,29 @@
+# FAQ
+
+## What is `eos`?
+
+[](https://github.com/embeddedos-org/eos/actions/workflows/ci.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/codeql.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/scorecard.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/release.yml) [](LICENSE)
+
+## Which branch does this wiki describe?
+
+The latest publication inspected `master` at [`d14b62f62d2e`](https://github.com/embeddedos-org/eos/commit/d14b62f62d2ed7a0393d1d99e433949cdca76973).
+
+## Where are setup instructions?
+
+Start with the [README](https://github.com/embeddedos-org/eos/blob/master/README.md), then use [Getting Started](Getting-Started) for a concise map of the checked-in project inputs.
+
+## How do I contribute?
+
+Use the [CONTRIBUTING](https://github.com/embeddedos-org/eos/blob/master/CONTRIBUTING.md) and the evidence-backed inventory on [Development](Development). If no root contributing guide exists, inspect the README, repository automation, and recent accepted changes before proposing work.
+
+## How do I run tests?
+
+[Development](Development) lists the 73 test-related paths found in the inspected tree and reproduces recognized test commands only when they appear in the root README or contributing guide.
+
+## How do I report a security issue?
+
+Follow [Security](Security). The source-tree policy status for this publication is: [SECURITY](https://github.com/embeddedos-org/eos/blob/master/SECURITY.md)
+
+## Is the wiki authoritative?
+
+No. The [embeddedos-org/eos source tree](https://github.com/embeddedos-org/eos) is authoritative. The wiki is a repository-specific guide to that source.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## Repository purpose
+
+[](https://github.com/embeddedos-org/eos/actions/workflows/ci.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/codeql.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/scorecard.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/release.yml) [](LICENSE)
+
+## First steps
+
+1. Read the [README](https://github.com/embeddedos-org/eos/blob/master/README.md) for the project's supported setup and usage path.
+2. Clone the repository and enter its directory:
+
+```bash
+git clone https://github.com/embeddedos-org/eos.git
+cd eos
+```
+
+3. Check the root project inputs below before installing dependencies or selecting a build tool.
+4. Review [Development](Development) before changing code, and [Security](Security) before reporting a vulnerability.
+
+## Root project inputs
+
+- `CMakeLists.txt`: CMake build definition.
+- `Dockerfile`: Container build definition.
+- `requirements-dev.txt`: Python development requirements.
+
+## Scope note
+
+The default branch inspected for this page was `master` at [`d14b62f62d2e`](https://github.com/embeddedos-org/eos/commit/d14b62f62d2ed7a0393d1d99e433949cdca76973). This page intentionally does not invent a universal build command when the repository's own documentation does not provide one.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,22 @@
+# eos
+
+[](https://github.com/embeddedos-org/eos/actions/workflows/ci.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/codeql.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/scorecard.yml) [](https://github.com/embeddedos-org/eos/actions/workflows/release.yml) [](LICENSE)
+
+This wiki is a maintained navigation layer for [embeddedos-org/eos](https://github.com/embeddedos-org/eos). Source files on the `master` default branch remain authoritative for code, commands, policies, and release behavior.
+
+## Start here
+
+- [Getting Started](Getting-Started) explains how to orient yourself using the repository's checked-in entry points.
+- [Development](Development) records the build manifests, contribution guidance, and tests found during the latest source inspection.
+- [Security](Security) points to the repository's vulnerability-reporting policy.
+- [FAQ](FAQ) answers common repository-specific navigation questions.
+
+## Source snapshot
+
+- Default branch: `master`
+- Inspected source commit: [`d14b62f62d2e`](https://github.com/embeddedos-org/eos/commit/d14b62f62d2ed7a0393d1d99e433949cdca76973)
+- Root project overview: [README](https://github.com/embeddedos-org/eos/blob/master/README.md)
+- Contribution guidance: [CONTRIBUTING](https://github.com/embeddedos-org/eos/blob/master/CONTRIBUTING.md)
+- Security policy: [SECURITY](https://github.com/embeddedos-org/eos/blob/master/SECURITY.md)
+
+The wiki was generated from repository content, but it does not replace that content. If a wiki statement and the source tree disagree, follow the source tree and open a documentation correction.

--- a/docs/wiki/Security.md
+++ b/docs/wiki/Security.md
@@ -1,0 +1,13 @@
+# Security
+
+## Reporting vulnerabilities
+
+The repository has a root [SECURITY](https://github.com/embeddedos-org/eos/blob/master/SECURITY.md). Follow that policy for supported versions, reporting channels, disclosure expectations, and response details.
+
+Do not publish suspected vulnerabilities in a public issue unless the policy explicitly directs you to do so. Provide a clear description, affected versions or commits, reproduction details, impact, and any known mitigation through the private channel named by the policy.
+
+## Evidence
+
+- Repository: [embeddedos-org/eos](https://github.com/embeddedos-org/eos)
+- Inspected branch: `master`
+- Inspected commit: [`d14b62f62d2e`](https://github.com/embeddedos-org/eos/commit/d14b62f62d2ed7a0393d1d99e433949cdca76973)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,8 @@
+**eos Wiki**
+
+- [Home](Home)
+- [Getting Started](Getting-Started)
+- [Development](Development)
+- [Security](Security)
+- [FAQ](FAQ)
+- [Source Repository](https://github.com/embeddedos-org/eos)


### PR DESCRIPTION
## Closing issue

Fixes #142

## Summary

Community governance rollout for eos: reconciled repo-specific AGENTS.md, pinned linked-issue policy workflow, versioned wiki sources under docs/wiki, and PR template with required Closing issue section.

## Validation

- Workflow YAML parses and pin verified locally (uses + policy_ref pinned to 92cb596c773496ec4df76717e8acf0e6b7700f73; no POLICY_COMMIT_SHA remainder).
- Wiki byte equality verified locally (6/6).
- AGENTS.md commands verified against files present in the fresh clone.
